### PR TITLE
Test/1127 cleanup text tests

### DIFF
--- a/.github/scripts/update.sh
+++ b/.github/scripts/update.sh
@@ -90,6 +90,7 @@ echo "iOS SDK last version is $version"
 pushd ios >/dev/null
 sed -i~ -e "s|s.dependency 'Didomi-XCFramework', '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.dependency 'Didomi-XCFramework', '$version'|g" didomi_sdk.podspec || exit 1
 sed -i~ -e "s|s.version          = '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.version          = '$flutterversion'|g" didomi_sdk.podspec || exit 1
+pod update || exit 1
 popd >/dev/null
 
 # Update Flutter version

--- a/example/integration_test/text_test.dart
+++ b/example/integration_test/text_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'util/assertion_helper.dart';
 import 'util/initialize_helper.dart';
 
 void main() {
@@ -14,6 +15,18 @@ void main() {
   final initializeBtnFinder = find.byKey(Key("initializeSmall"));
   final getTextBtnFinder = find.byKey(Key("getText"));
   final getWebviewStringsBtnFinder = find.byKey(Key("getWebviewStrings"));
+
+  // Messages
+  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
+  final expectedResult = "Native message: fr =>Avec votre consentement, nous et <a href=\"javascript:Didomi.preferences.show('vendors')\">nos partenaires</a> "
+      "utilisons l'espace de stockage du terminal pour stocker et accéder à des données personnelles telles que des données de géolocalisation "
+      "précises et d'identification par analyse du terminal. Nous traitons ces données à des fins telles que les publicités et contenus personnalisés, "
+      "la mesure de performance des publicités et du contenu, les données d'audience et le développement des produits. Vous pouvez à tout moment retirer "
+      "votre consentement ou vous opposer au traitement des données sur la base de l'intérêt légitime depuis le menu de l'application.en =>With your "
+      "agreement, we and <a href=\"javascript:Didomi.preferences.show('vendors')\">our partners</a> use device storage to store and access personal data "
+      "like precise geolocation data, and identification through device scanning. We process that data for purposes like personalised ads and content, "
+      "ad and content measurement, audience insights and product development. You can withdraw your consent or object to data processing based on "
+      "legitimate interest at any time from the app menu.";
 
   bool isError = false;
   bool isReady = false;
@@ -40,15 +53,7 @@ void main() {
       await tester.tap(getTextBtnFinder);
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-              (Widget widget) =>
-          widget is Text &&
-              widget.key.toString().contains("getText") &&
-              widget.data?.contains("Native message: Failed: \'Didomi SDK is not ready. Use the onReady callback to access this method.\'.") == true,
-        ),
-        findsOneWidget,
-      );
+      assertNativeMessage("getText", notReadyMessage);
     });
 
     testWidgets("Get Text after initialization", (WidgetTester tester) async {
@@ -64,12 +69,7 @@ void main() {
       await tester.tap(getTextBtnFinder);
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-              (Widget widget) => widget is Text && widget.key.toString().contains("getText") && widget.data?.startsWith("Native message: \nen =>") == true,
-        ),
-        findsOneWidget,
-      );
+      assertNativeMessage("getText", expectedResult);
     });
 
     testWidgets("Get webView string after initialization", (WidgetTester tester) async {

--- a/example/integration_test/translated_text_test.dart
+++ b/example/integration_test/translated_text_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'util/assertion_helper.dart';
 import 'util/initialize_helper.dart';
 
 void main() {
@@ -14,6 +15,11 @@ void main() {
   final updateSelectedLanguageBtnFinder = find.byKey(Key("updateSelectedLanguage"));
   final getTranslatedTextBtnFinder = find.byKey(Key("getTranslatedText"));
   final languageCodeToUpdateFieldFinder = find.byKey(Key("languageCodeToUpdate"));
+
+  // Messages
+  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
+  final expectedConsentEn = "Native message: With your agreement, we";
+  final expectedConsentFr = "Native message: Avec votre consentement, nous";
 
   bool isError = false;
   bool isReady = false;
@@ -40,15 +46,7 @@ void main() {
       await tester.tap(getTranslatedTextBtnFinder);
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-              (Widget widget) =>
-          widget is Text &&
-              widget.key.toString().contains("getTranslatedText") &&
-              widget.data?.contains("Native message: Failed: \'Didomi SDK is not ready. Use the onReady callback to access this method.\'.") == true,
-        ),
-        findsOneWidget,
-      );
+      assertNativeMessage("getTranslatedText", notReadyMessage);
     });
 
     testWidgets("Get Translated Texts after initialization", (WidgetTester tester) async {
@@ -65,15 +63,7 @@ void main() {
       await tester.tap(getTranslatedTextBtnFinder);
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-              (Widget widget) =>
-          widget is Text &&
-              widget.key.toString().contains("getTranslatedText") &&
-              widget.data?.startsWith("Native message: With your agreement, we") == true,
-        ),
-        findsOneWidget,
-      );
+      assertNativeMessageStartsWith("getTranslatedText", expectedConsentEn);
     });
 
     testWidgets("Get Translated Texts after invalid language update", (WidgetTester tester) async {
@@ -96,15 +86,7 @@ void main() {
       await tester.tap(getTranslatedTextBtnFinder);
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-              (Widget widget) =>
-          widget is Text &&
-              widget.key.toString().contains("getTranslatedText") &&
-              widget.data?.startsWith("Native message: With your agreement, we") == true,
-        ),
-        findsOneWidget,
-      );
+      assertNativeMessageStartsWith("getTranslatedText", expectedConsentEn);
     });
 
     testWidgets("Get Translated Texts after valid language update", (WidgetTester tester) async {
@@ -127,15 +109,7 @@ void main() {
       await tester.tap(getTranslatedTextBtnFinder);
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-              (Widget widget) =>
-          widget is Text &&
-              widget.key.toString().contains("getTranslatedText") &&
-              widget.data?.startsWith("Native message: Avec votre consentement, nous") == true,
-        ),
-        findsOneWidget,
-      );
+      assertNativeMessageStartsWith("getTranslatedText", expectedConsentFr);
     });
   });
 }

--- a/example/lib/widgets/get_text.dart
+++ b/example/lib/widgets/get_text.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:didomi_sdk/didomi_sdk.dart';
 import 'package:didomi_sdk_example/widgets/base_sample_widget_state.dart';
@@ -28,7 +29,9 @@ class _GetTextState extends BaseSampleWidgetState<GetText> {
     if (result == null) {
       sb.writeln("No result");
     } else {
-      result.entries.forEach((element) {
+      // Sort result for UI tests
+      final sorted = SplayTreeMap<String, dynamic>.from(result, (a, b) => result[a]!.compareTo(result[b]!));
+      sorted.entries.forEach((element) {
         sb.writeln("${element.key} =>");
         sb.writeln(element.value);
       });


### PR DESCRIPTION
Relates to: CMP-1127

I had to sort the` getText()` result from native to ensure the response will match the expected result and prevent random failures