### PR TITLE
Test/1127 use constant

### DIFF
--- a/example/integration_test/purpose_test.dart
+++ b/example/integration_test/purpose_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'util/assertion_helper.dart';
+import 'util/constants.dart';
 import 'util/initialize_helper.dart';
 import 'util/scroll_helper.dart';
 
@@ -28,9 +29,10 @@ void main() {
   bool isReady = false;
 
   // Native message strings.
-  final purposeNames = "purpose_1_name, purpose_3_name, purpose_5_name, special_feature_2_name, special_feature_1_name, purpose_10_name, purpose_9_name, purpose_7_name, purpose_8_name, purpose_2_name, purpose_4_name, purpose_6_name.";
-  final purposeIds = "cookies, create_ads_profile, create_content_profile, device_characteristics, geolocation_data, improve_products, market_research, measure_ad_performance, measure_content_performance, select_basic_ads, select_personalized_ads, select_personalized_content.";
-  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
+  const purposeNames = "purpose_1_name, purpose_3_name, purpose_5_name, special_feature_2_name, special_feature_1_name, purpose_10_name, purpose_9_name, "
+      "purpose_7_name, purpose_8_name, purpose_2_name, purpose_4_name, purpose_6_name.";
+  const purposeIds = "cookies, create_ads_profile, create_content_profile, device_characteristics, geolocation_data, improve_products, market_research, "
+      "measure_ad_performance, measure_content_performance, select_basic_ads, select_personalized_ads, select_personalized_content.";
 
   final listener = EventListener();
   listener.onError = (String message) {
@@ -58,8 +60,7 @@ void main() {
       await tester.tap(disabledPurposeIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getDisabledPurposeIds", expected);
+      assertNativeMessage("getDisabledPurposeIds", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -76,8 +77,7 @@ void main() {
       await tester.tap(enabledPurposeIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getEnabledPurposeIds", expected);
+      assertNativeMessage("getEnabledPurposeIds", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -94,8 +94,7 @@ void main() {
       await tester.tap(requiredPurposeIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getRequiredPurposeIds", expected);
+      assertNativeMessage("getRequiredPurposeIds", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -113,8 +112,7 @@ void main() {
       await tester.tap(disabledPurposesBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getDisabledPurposes", expected);
+      assertNativeMessage("getDisabledPurposes", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -132,8 +130,7 @@ void main() {
       await tester.tap(enabledPurposesBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getEnabledPurposes", expected);
+      assertNativeMessage("getEnabledPurposes", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -151,8 +148,7 @@ void main() {
       await tester.tap(requiredPurposesBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getRequiredPurposes", expected);
+      assertNativeMessage("getRequiredPurposes", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -170,8 +166,7 @@ void main() {
       await tester.tap(getPurposesBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getPurpose", expected);
+      assertNativeMessage("getPurpose", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);

--- a/example/integration_test/text_test.dart
+++ b/example/integration_test/text_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'util/assertion_helper.dart';
+import 'util/constants.dart';
 import 'util/initialize_helper.dart';
 
 void main() {
@@ -17,8 +18,7 @@ void main() {
   final getWebviewStringsBtnFinder = find.byKey(Key("getWebviewStrings"));
 
   // Messages
-  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
-  final expectedResult = "Native message: fr =>Avec votre consentement, nous et <a href=\"javascript:Didomi.preferences.show('vendors')\">nos partenaires</a> "
+  const expectedResult = "Native message: fr =>Avec votre consentement, nous et <a href=\"javascript:Didomi.preferences.show('vendors')\">nos partenaires</a> "
       "utilisons l'espace de stockage du terminal pour stocker et accéder à des données personnelles telles que des données de géolocalisation "
       "précises et d'identification par analyse du terminal. Nous traitons ces données à des fins telles que les publicités et contenus personnalisés, "
       "la mesure de performance des publicités et du contenu, les données d'audience et le développement des produits. Vous pouvez à tout moment retirer "

--- a/example/integration_test/translated_text_test.dart
+++ b/example/integration_test/translated_text_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'util/assertion_helper.dart';
+import 'util/constants.dart';
 import 'util/initialize_helper.dart';
 
 void main() {
@@ -17,9 +18,8 @@ void main() {
   final languageCodeToUpdateFieldFinder = find.byKey(Key("languageCodeToUpdate"));
 
   // Messages
-  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
-  final expectedConsentEn = "Native message: With your agreement, we";
-  final expectedConsentFr = "Native message: Avec votre consentement, nous";
+  const expectedConsentEn = "Native message: With your agreement, we";
+  const expectedConsentFr = "Native message: Avec votre consentement, nous";
 
   bool isError = false;
   bool isReady = false;

--- a/example/integration_test/user_li_test.dart
+++ b/example/integration_test/user_li_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'util/assertion_helper.dart';
+import 'util/constants.dart';
 import 'util/initialize_helper.dart';
 import 'util/scroll_helper.dart';
 
@@ -22,12 +23,11 @@ void main() {
   final listKey = Key("components_list");
 
   // Messages
-  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
-  final enabledForPurposeMessage = "Native message: User status is 'Enabled' for purpose 'cookies'.";
-  final enabledForVendorMessage = "Native message: User status is 'Enabled' for vendor '738'.";
-  final disabledForVendorMessage = "Native message: User status is 'Disabled' for vendor '738'.";
-  final enabledForVendorAndRequiredPurposesMessage = "Native message: User status is 'Enabled' for vendor '738' and required purposes.";
-  final disabledForVendorAndRequiredPurposesMessage = "Native message: User status is 'Disabled' for vendor '738' and required purposes.";
+  const enabledForPurposeMessage = "Native message: User status is 'Enabled' for purpose 'cookies'.";
+  const enabledForVendorMessage = "Native message: User status is 'Enabled' for vendor '738'.";
+  const disabledForVendorMessage = "Native message: User status is 'Disabled' for vendor '738'.";
+  const enabledForVendorAndRequiredPurposesMessage = "Native message: User status is 'Enabled' for vendor '738' and required purposes.";
+  const disabledForVendorAndRequiredPurposesMessage = "Native message: User status is 'Disabled' for vendor '738' and required purposes.";
 
   bool isError = false;
   bool isReady = false;

--- a/example/integration_test/util/constants.dart
+++ b/example/integration_test/util/constants.dart
@@ -1,0 +1,2 @@
+/// Common messages for assertions
+const notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";

--- a/example/integration_test/vendor_test.dart
+++ b/example/integration_test/vendor_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'util/assertion_helper.dart';
+import 'util/constants.dart';
 import 'util/initialize_helper.dart';
 import 'util/scroll_helper.dart';
 
@@ -25,8 +26,36 @@ void main() {
   final listKey = Key("components_list");
 
   // Native message strings.
-  final vendorNames = "Exponential Interactive, Inc d/b/a VDX.tv, Index Exchange, Inc. , Fifty";
-  final notReadyMessage = "Native message: Failed: 'Didomi SDK is not ready. Use the onReady callback to access this method.'.";
+  const emptyDisabledVendorMessage = "Native message: Disabled Vendor list is empty.";
+  const emptyEnabledVendorMessage = "Native message: Enabled Vendor list is empty.";
+  const suffixVendorMessage = "1, 10, 100, 1000, 1001, 1002, 1003, 1004, 1006, 1007, 101, 1010, 1011, 1012, 1015, 1016, 102, 104, 108, 109, 11, 110, "
+      "111, 114, 115, 119, 12, 120, 122, 124, 126, 127, 128, 129, 13, 130, 131, 132, 133, 134, 136, 137, 138, 139, 14, 140, 141, 142, 143, 144, 145, 147, "
+      "148, 149, 15, 150, 151, 152, 153, 154, 155, 157, 158, 159, 16, 160, 161, 162, 163, 164, 165, 167, 168, 170, 173, 174, 177, 178, 179, 18, 183, "
+      "184, 185, 190, 192, 193, 194, 195, 196, 198, 199, 2, 20, 200, 202, 203, 205, 206, 208, 209, 21, 210, 211, 212, 213, 215, 216, 217, 218, 22, 223, "
+      "224, 226, 227, 228, 23, 230, 231, 234, 235, 236, 237, 238, 239, 24, 240, 241, 242, 243, 244, 246, 248, 249, 25, 250, 251, 252, 253, 254, 255, "
+      "256, 259, 26, 261, 262, 263, 264, 265, 266, 27, 270, 272, 273, 274, 275, 276, 277, 28, 281, 282, 284, 285, 289, 29, 290, 293, 294, 295, 297, 298, "
+      "299, 30, 301, 302, 303, 304, 308, 31, 310, 311, 312, 314, 315, 316, 317, 318, 319, 32, 321, 323, 325, 328, 329, 33, 331, 333, 335, 336, 337, 34, "
+      "343, 345, 347, 349, 350, 351, 354, 358, 359, 36, 360, 361, 368, 37, 371, 373, 374, 375, 377, 378, 380, 381, 382, 385, 387, 388, 39, 394, 397, 4, "
+      "40, 402, 408, 409, 41, 410, 412, 413, 416, 418, 42, 422, 423, 424, 427, 428, 429, 434, 435, 436, 438, 439, 44, 440, 444, 447, 448, 45, 450, 452, "
+      "455, 458, 459, 46, 461, 462, 467, 468, 469, 47, 471, 473, 475, 479, 48, 482, 486, 488, 49, 490, 491, 493, 495, 496, 498, 50, 501, 502, 505, 506, "
+      "507, 508, 509, 51, 511, 512, 516, 517, 519, 52, 520, 521, 524, 527, 528, 53, 530, 531, 535, 536, 539, 541, 543, 544, 545, 546, 547, 549, 550, 553, "
+      "554, 556, 559, 561, 565, 568, 569, 57, 570, 571, 573, 574, 577, 578, 579, 58, 580, 584, 587, 59, 590, 591, 593, 596, 597, 598, 6, 60, 601, 602, "
+      "606, 607, 609, 61, 610, 612, 613, 614, 615, 617, 618, 62, 620, 621, 624, 625, 626, 628, 63, 630, 631, 638, 639, 644, 645, 646, 647, 648, 649, 65, "
+      "650, 652, 653, 654, 655, 656, 657, 658, 659, 66, 662, 663, 664, 665, 666, 667, 668, 67, 670, 671, 672, 674, 675, 676, 678, 68, 681, 682, 683, 685, "
+      "686, 687, 69, 690, 691, 694, 697, 699, 7, 70, 702, 703, 707, 708, 709, 71, 711, 712, 713, 714, 715, 716, 717, 718, 719, 72, 720, 721, 722, 723, "
+      "724, 725, 726, 727, 728, 73, 731, 732, 733, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 753, 754, 756, "
+      "757, 758, 759, 76, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 77, 770, 771, 773, 775, 776, 777, 778, 779, 78, 780, 781, 782, 783, 784, 785, "
+      "787, 788, 789, 79, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 8, 80, 800, 801, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, "
+      "814, 816, 817, 818, 819, 82, 820, 821, 822, 823, 824, 825, 826, 827, 829, 83, 831, 832, 833, 834, 835, 836, 837, 839, 84, 840, 842, 843, 844, 845, "
+      "846, 847, 848, 849, 85, 850, 851, 852, 854, 855, 856, 857, 858, 859, 86, 860, 861, 862, 863, 864, 865, 866, 867, 868, 869, 87, 870, 871, 874, 875, "
+      "876, 877, 878, 88, 880, 882, 884, 885, 886, 887, 888, 889, 89, 890, 891, 893, 894, 895, 896, 897, 899, 9, 90, 900, 901, 902, 903, 905, 906, 907, "
+      "908, 909, 91, 910, 912, 913, 914, 915, 917, 918, 919, 92, 920, 921, 922, 924, 926, 928, 929, 93, 930, 932, 933, 934, 935, 936, 937, 938, 94, 940, "
+      "941, 942, 943, 944, 946, 947, 948, 95, 951, 952, 955, 957, 958, 959, 961, 962, 963, 964, 965, 966, 967, 968, 97, 970, 971, 972, 973, 974, 975, 976, "
+      "977, 978, 979, 98, 980, 981, 982, 983, 984, 985, 986, 987, 988, 989, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999, google.";
+  const disabledVendorMessage = "Native message: Disabled Vendors: $suffixVendorMessage";
+  const enabledVendorMessage = "Native message: Enabled Vendors: $suffixVendorMessage";
+  const requiredVendorMessage = "Native message: Required Vendors: $suffixVendorMessage";
+  const vendorNames = "Exponential Interactive, Inc d/b/a VDX.tv, Index Exchange, Inc. , Fifty";
 
   bool isError = false;
   bool isReady = false;
@@ -57,8 +86,7 @@ void main() {
       await tester.tap(disabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getDisabledVendorIds", expected);
+      assertNativeMessage("getDisabledVendorIds", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -75,8 +103,7 @@ void main() {
       await tester.tap(enabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getEnabledVendorIds", expected);
+      assertNativeMessage("getEnabledVendorIds", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -93,8 +120,7 @@ void main() {
       await tester.tap(requiredVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getRequiredVendorIds", expected);
+      assertNativeMessage("getRequiredVendorIds", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -112,8 +138,7 @@ void main() {
       await tester.tap(disabledVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getDisabledVendors", expected);
+      assertNativeMessage("getDisabledVendors", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -131,8 +156,7 @@ void main() {
       await tester.tap(enabledVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getEnabledVendors", expected);
+      assertNativeMessage("getEnabledVendors", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -150,8 +174,7 @@ void main() {
       await tester.tap(requiredVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getRequiredVendors", expected);
+      assertNativeMessage("getRequiredVendors", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -171,8 +194,7 @@ void main() {
       await tester.tap(getVendorBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = notReadyMessage;
-      assertNativeMessage("getVendor", expected);
+      assertNativeMessage("getVendor", notReadyMessage);
 
       assert(isError == false);
       assert(isReady == false);
@@ -195,8 +217,7 @@ void main() {
       await tester.tap(disabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Disabled Vendor list is empty.";
-      assertNativeMessage("getDisabledVendorIds", expected);
+      assertNativeMessage("getDisabledVendorIds", emptyDisabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -213,8 +234,7 @@ void main() {
       await tester.tap(enabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Enabled Vendor list is empty.";
-      assertNativeMessage("getEnabledVendorIds", expected);
+      assertNativeMessage("getEnabledVendorIds", emptyEnabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -231,8 +251,7 @@ void main() {
       await tester.tap(requiredVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Required Vendors: 1, 10, 100, 1000, 1001, 1002, ";
-      assertNativeMessageStartsWith("getRequiredVendorIds", expected);
+      assertNativeMessage("getRequiredVendorIds", requiredVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -250,8 +269,7 @@ void main() {
       await tester.tap(disabledVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Disabled Vendor list is empty.";
-      assertNativeMessage("getDisabledVendors", expected);
+      assertNativeMessage("getDisabledVendors", emptyDisabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -269,8 +287,7 @@ void main() {
       await tester.tap(enabledVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Enabled Vendor list is empty.";
-      assertNativeMessage("getEnabledVendors", expected);
+      assertNativeMessage("getEnabledVendors", emptyEnabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -334,8 +351,7 @@ void main() {
       await tester.tap(disabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Disabled Vendor list is empty.";
-      assertNativeMessage("getDisabledVendorIds", expected);
+      assertNativeMessage("getDisabledVendorIds", emptyDisabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -352,8 +368,7 @@ void main() {
       await tester.tap(enabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Enabled Vendors: 1, 10, 100, 1000, 1001, 1002, ";
-      assertNativeMessageStartsWith("getEnabledVendorIds", expected);
+      assertNativeMessage("getEnabledVendorIds", enabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -370,8 +385,7 @@ void main() {
       await tester.tap(requiredVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Required Vendors: 1, 10, 100, 1000, 1001, 1002, ";
-      assertNativeMessageStartsWith("getRequiredVendorIds", expected);
+      assertNativeMessage("getRequiredVendorIds", requiredVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -389,8 +403,7 @@ void main() {
       await tester.tap(disabledVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Disabled Vendor list is empty.";
-      assertNativeMessage("getDisabledVendors", expected);
+      assertNativeMessage("getDisabledVendors", emptyDisabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -473,8 +486,7 @@ void main() {
       await tester.tap(disabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Disabled Vendors: 1, 10, 100, 1000, 1001, 1002, ";
-      assertNativeMessageStartsWith("getDisabledVendorIds", expected);
+      assertNativeMessage("getDisabledVendorIds", disabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -491,8 +503,7 @@ void main() {
       await tester.tap(enabledVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Enabled Vendor list is empty.";
-      assertNativeMessage("getEnabledVendorIds", expected);
+      assertNativeMessage("getEnabledVendorIds", emptyEnabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -509,8 +520,7 @@ void main() {
       await tester.tap(requiredVendorIdsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Required Vendors: 1, 10, 100, 1000, 1001, 1002, ";
-      assertNativeMessageStartsWith("getRequiredVendorIds", expected);
+      assertNativeMessage("getRequiredVendorIds", requiredVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);
@@ -547,8 +557,7 @@ void main() {
       await tester.tap(enabledVendorsBtnFinder);
       await tester.pumpAndSettle();
 
-      final expected = "Native message: Enabled Vendor list is empty.";
-      assertNativeMessage("getEnabledVendors", expected);
+      assertNativeMessage("getEnabledVendors", emptyEnabledVendorMessage);
 
       assert(isError == false);
       assert(isReady == true);

--- a/example/lib/extensions/splay_tree_map.dart
+++ b/example/lib/extensions/splay_tree_map.dart
@@ -3,7 +3,7 @@ import 'dart:collection';
 /// SplayTreeMap extension.
 extension SplayTreeMapPrettyPrint on SplayTreeMap {
   /// Extension method used to print content.
-  String pretty(String prefix) {
+  String joinToString(String prefix) {
     StringBuffer sb = StringBuffer(prefix);
     this.entries.forEach((element) {
       sb.writeln("${element.key} =>");

--- a/example/lib/widgets/get_text.dart
+++ b/example/lib/widgets/get_text.dart
@@ -32,7 +32,7 @@ class _GetTextState extends BaseSampleWidgetState<GetText> {
       // Sort result for UI tests
       final sorted = result.sortByKey();
       // Pretty print for content
-      return sorted.pretty("\n");
+      return sorted.joinToString("\n");
     }
   }
 


### PR DESCRIPTION
Relates to: CMP-1127

Use constants for expected messages and extract the sdk not init message
rename SplayTreeMap extension (pretty -> joinToString - same as list extension)