### PR TITLE
Refactor/2125 gcloud auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -47,8 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -76,10 +75,10 @@ jobs:
   build_ios:
     name: Build for iOS
     needs: analyse
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/test_android.yml
+++ b/.github/workflows/test_android.yml
@@ -55,14 +55,15 @@ jobs:
         run: flutter pub get
 
       # Connect to GCloud
-      - name: Login to Google Cloud
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          version: "342.0.0"
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
-
-      - name: Set current project
-        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+          project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
 
       # Build and upload each scenarios to firebase
       - name: Run UI tests

--- a/.github/workflows/test_android.yml
+++ b/.github/workflows/test_android.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: "12.x"

--- a/.github/workflows/test_ios.yml
+++ b/.github/workflows/test_ios.yml
@@ -65,14 +65,15 @@ jobs:
         run: security unlock-keychain -p ${{ secrets.KEYCHAIN_PWD }} login.keychain
 
       # Connect to GCloud
-      - name: Login to Google Cloud
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          version: "342.0.0"
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
-
-      - name: Set current project
-        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+          project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
 
       # Build and upload each scenarios to firebase
       - name: Run UI tests

--- a/.github/workflows/test_ios.yml
+++ b/.github/workflows/test_ios.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -43,7 +43,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-latest # required for pod info / update
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: "12.x"
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: "12.x"
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -108,7 +108,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -89,14 +89,15 @@ jobs:
         run: flutter pub get
 
       # Connect to GCloud
-      - name: Login to Google Cloud
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          version: "342.0.0"
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
-
-      - name: Set current project
-        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+          project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
 
       # Build and upload each scenarios to firebase
       - name: Run UI tests
@@ -130,14 +131,15 @@ jobs:
         run: security unlock-keychain -p ${{ secrets.KEYCHAIN_PWD }} login.keychain
 
       # Connect to GCloud
-      - name: Login to Google Cloud
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          version: "342.0.0"
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
-
-      - name: Set current project
-        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+          project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
 
       # Build and upload each scenarios to firebase
       - name: Run UI tests


### PR DESCRIPTION
Closes: CMP-2125

Update CI scripts:
- use checkout v3
- use `google-github-actions/auth` for GCLOUD auth