### PR TITLE
Split native sdks version update and flutter version increment

### DIFF
--- a/.github/scripts/update.sh
+++ b/.github/scripts/update.sh
@@ -1,104 +1,13 @@
 #!/bin/bash
 
-#----------------------------------------------------------
+#---------------------------------------------------------------------------------------------
 # Update Android and iOS SDKs version (latest from repos)
+# THEN
 # Increment Flutter version (from param major|minor|patch)
 #   No argument: use patch as default
+# Update Change log by providing the new flutter version and the current native SDKs version
 # Update flutter dependencies
-# Commit and push changes
-#----------------------------------------------------------
+#---------------------------------------------------------------------------------------------
 
-# set nocasematch option
-shopt -s nocasematch
-
-# Increment position (Patch is default)
-if [[ "$1" =~ ^major$ ]]; then
-  position=0
-elif [[ "$1" =~ ^minor$ ]]; then
-  position=1
-else
-  position=2
-fi
-
-# unset nocasematch option
-shopt -u nocasematch
-
-# Increment version (eg `sh increment_version 1.2.3 1` returns `1.3.0`)
-# args:
-#   - version number (eg `0.32.4`)
-#   - increment number: `0` (major) | `1` (minor) | `2` (patch)
-increment_version() {
-  local delimiter=.
-  local array=($(echo "$1" | tr $delimiter '\n'))
-  array[$2]=$((array[$2] + 1))
-  if [ $2 -lt 2 ]; then array[2]=0; fi
-  if [ $2 -lt 1 ]; then array[1]=0; fi
-  echo $(
-    local IFS=$delimiter
-    echo "${array[*]}"
-  )
-}
-
-# Get last version from pod
-pod_last_version() {
-  lastversion=""
-  for line in $(pod trunk info Didomi-XCFramework); do
-    if [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      lastversion=$line
-    fi
-  done
-  echo "$lastversion"
-}
-
-# Get Flutter version
-version=$(sh .github/scripts/extract_flutter_version.sh)
-if [[ ! $version =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-  echo "Error while getting Flutter version"
-  exit 1
-fi
-
-# Increment Flutter version
-flutterversion=$(increment_version "$version" $position)
-echo "Flutter version will change from $version to $flutterversion"
-
-# Update android SDK Version
-androidVersion=$(curl -s 'https://search.maven.org/solrsearch/select?q=didomi' | sed -n 's|.*"latestVersion":"\([^"]*\)".*|\1|p')
-if [[ ! $version =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-  echo "Error while getting android SDK version"
-  exit 1
-fi
-
-echo "Android SDK last version is $androidVersion"
-
-pushd android >/dev/null
-sed -i~ -e "s|io.didomi.sdk:android:[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|io.didomi.sdk:android:$androidVersion|g" build.gradle || exit 1
-sed -i~ -e "s|^version = \"[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\"|version = \"$flutterversion\"|g" build.gradle || exit 1
-popd >/dev/null
-
-# Update ios SDK Version
-iOSVersion=$(pod_last_version)
-if [[ ! $version =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-  echo "Error while getting ios SDK version"
-  exit 1
-fi
-
-echo "iOS SDK last version is $iOSVersion"
-
-pushd ios >/dev/null
-sed -i~ -e "s|s.dependency       'Didomi-XCFramework', '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.dependency       'Didomi-XCFramework', '$iOSVersion'|g" didomi_sdk.podspec || exit 1
-sed -i~ -e "s|s.version          = '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.version          = '$flutterversion'|g" didomi_sdk.podspec || exit 1
-popd >/dev/null
-
-pushd example/ios >/dev/null
-pod repo update || exit 1
-pod update || exit 1
-popd >/dev/null
-
-# Update Flutter version
-sed -i~ -e "s|version: [0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|version: $flutterversion|g" pubspec.yaml || exit 1
-
-# Update changelog
-sh .github/scripts/update_changelog.sh "$flutterversion" "$androidVersion" "$iOSVersion" || exit 1
-
-# Reload dependencies
-flutter pub get || exit 1
+sh .github/scripts/update_native_sdks.sh || exit 1
+sh .github/scripts/update_bridge_version.sh "$1" || exit 1

--- a/.github/scripts/update_bridge_version.sh
+++ b/.github/scripts/update_bridge_version.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#---------------------------------------------------------------------------------------------
+# Increment Flutter version (from param major|minor|patch)
+#   No argument: use patch as default
+# Update Change log by providing the new flutter version and the current native SDKs version
+# Update flutter dependencies
+#---------------------------------------------------------------------------------------------
+
+# set nocasematch option
+shopt -s nocasematch
+
+# Increment position (Patch is default)
+if [[ "$1" =~ ^major$ ]]; then
+  position=0
+elif [[ "$1" =~ ^minor$ ]]; then
+  position=1
+else
+  position=2
+fi
+
+# unset nocasematch option
+shopt -u nocasematch
+
+# Increment version (eg `sh increment_version 1.2.3 1` returns `1.3.0`)
+# args:
+#   - version number (eg `0.32.4`)
+#   - increment number: `0` (major) | `1` (minor) | `2` (patch)
+increment_version() {
+  local delimiter=.
+  local array=($(echo "$1" | tr $delimiter '\n'))
+  array[$2]=$((array[$2] + 1))
+  if [ $2 -lt 2 ]; then array[2]=0; fi
+  if [ $2 -lt 1 ]; then array[1]=0; fi
+  echo $(
+    local IFS=$delimiter
+    echo "${array[*]}"
+  )
+}
+
+# Get Flutter version
+version=$(sh .github/scripts/extract_flutter_version.sh)
+if [[ ! $version =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  echo "Error while getting Flutter version"
+  exit 1
+fi
+
+# Increment Flutter version
+flutterversion=$(increment_version "$version" $position)
+echo "Flutter version will change from $version to $flutterversion"
+
+# Get current android SDK Version
+pushd android >/dev/null
+androidVersion=$(cat build.gradle | sed -n 's|.*"io.didomi.sdk:android:\([^"]*\)".*|\1|p')
+popd >/dev/null
+if [[ ! $androidVersion =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  echo "Error while getting android SDK version ($androidVersion)"
+  exit 1
+fi
+
+echo "Android SDK current version is $androidVersion"
+
+# Get current ios SDK Version
+pushd ios >/dev/null
+iOSVersion=$(cat didomi_sdk.podspec | sed -n "s|.*'Didomi-XCFramework', '\([^']*\)'.*|\1|p")
+popd >/dev/null
+if [[ ! $iOSVersion =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  echo "Error while getting ios SDK version ($iOSVersion)"
+  exit 1
+fi
+
+echo "iOS SDK current version is $iOSVersion"
+
+# Update Flutter version
+sed -i~ -e "s|version: [0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|version: $flutterversion|g" pubspec.yaml || exit 1
+
+pushd android >/dev/null
+sed -i~ -e "s|^version = \"[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\"|version = \"$flutterversion\"|g" build.gradle || exit 1
+popd >/dev/null
+
+pushd ios >/dev/null
+sed -i~ -e "s|s.version          = '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.version          = '$flutterversion'|g" didomi_sdk.podspec || exit 1
+popd >/dev/null
+
+# Update changelog
+sh .github/scripts/update_changelog.sh "$flutterversion" "$androidVersion" "$iOSVersion" || exit 1
+
+# Reload dependencies
+flutter pub get || exit 1

--- a/.github/scripts/update_bridge_version.sh
+++ b/.github/scripts/update_bridge_version.sh
@@ -73,13 +73,19 @@ echo "iOS SDK current version is $iOSVersion"
 
 # Update Flutter version
 sed -i~ -e "s|version: [0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|version: $flutterversion|g" pubspec.yaml || exit 1
+# Cleanup backup files
+find . -type f -name '*~' -delete
 
 pushd android >/dev/null
 sed -i~ -e "s|^version = \"[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\"|version = \"$flutterversion\"|g" build.gradle || exit 1
+# Cleanup backup files
+find . -type f -name '*~' -delete
 popd >/dev/null
 
 pushd ios >/dev/null
 sed -i~ -e "s|s.version          = '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.version          = '$flutterversion'|g" didomi_sdk.podspec || exit 1
+# Cleanup backup files
+find . -type f -name '*~' -delete
 popd >/dev/null
 
 # Update changelog

--- a/.github/scripts/update_bridge_version.sh
+++ b/.github/scripts/update_bridge_version.sh
@@ -73,23 +73,20 @@ echo "iOS SDK current version is $iOSVersion"
 
 # Update Flutter version
 sed -i~ -e "s|version: [0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|version: $flutterversion|g" pubspec.yaml || exit 1
-# Cleanup backup files
-find . -type f -name '*~' -delete
 
 pushd android >/dev/null
 sed -i~ -e "s|^version = \"[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\"|version = \"$flutterversion\"|g" build.gradle || exit 1
-# Cleanup backup files
-find . -type f -name '*~' -delete
 popd >/dev/null
 
 pushd ios >/dev/null
 sed -i~ -e "s|s.version          = '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.version          = '$flutterversion'|g" didomi_sdk.podspec || exit 1
-# Cleanup backup files
-find . -type f -name '*~' -delete
 popd >/dev/null
 
 # Update changelog
 sh .github/scripts/update_changelog.sh "$flutterversion" "$androidVersion" "$iOSVersion" || exit 1
+
+# Cleanup backup files
+find . -type f -name '*~' -delete
 
 # Reload dependencies
 flutter pub get || exit 1

--- a/.github/scripts/update_native_sdks.sh
+++ b/.github/scripts/update_native_sdks.sh
@@ -26,6 +26,8 @@ echo "Android SDK last version is $androidVersion"
 
 pushd android >/dev/null
 sed -i~ -e "s|io.didomi.sdk:android:[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|io.didomi.sdk:android:$androidVersion|g" build.gradle || exit 1
+# Cleanup backup files
+find . -type f -name '*~' -delete
 popd >/dev/null
 
 # Update ios SDK Version
@@ -39,6 +41,8 @@ echo "iOS SDK last version is $iOSVersion"
 
 pushd ios >/dev/null
 sed -i~ -e "s|s.dependency       'Didomi-XCFramework', '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.dependency       'Didomi-XCFramework', '$iOSVersion'|g" didomi_sdk.podspec || exit 1
+# Cleanup backup files
+find . -type f -name '*~' -delete
 popd >/dev/null
 
 pushd example/ios >/dev/null

--- a/.github/scripts/update_native_sdks.sh
+++ b/.github/scripts/update_native_sdks.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#----------------------------------------------------------
+# Update Android and iOS SDKs version (latest from repos)
+#----------------------------------------------------------
+
+# Get last version from pod
+pod_last_version() {
+  lastversion=""
+  for line in $(pod trunk info Didomi-XCFramework); do
+    if [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      lastversion=$line
+    fi
+  done
+  echo "$lastversion"
+}
+
+# Update android SDK Version
+androidVersion=$(curl -s 'https://search.maven.org/solrsearch/select?q=didomi' | sed -n 's|.*"latestVersion":"\([^"]*\)".*|\1|p')
+if [[ ! $androidVersion =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  echo "Error while getting android SDK version ($androidVersion)"
+  exit 1
+fi
+
+echo "Android SDK last version is $androidVersion"
+
+pushd android >/dev/null
+sed -i~ -e "s|io.didomi.sdk:android:[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|io.didomi.sdk:android:$androidVersion|g" build.gradle || exit 1
+popd >/dev/null
+
+# Update ios SDK Version
+iOSVersion=$(pod_last_version)
+if [[ ! $iOSVersion =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  echo "Error while getting ios SDK version ($iOSVersion)"
+  exit 1
+fi
+
+echo "iOS SDK last version is $iOSVersion"
+
+pushd ios >/dev/null
+sed -i~ -e "s|s.dependency       'Didomi-XCFramework', '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.dependency       'Didomi-XCFramework', '$iOSVersion'|g" didomi_sdk.podspec || exit 1
+popd >/dev/null
+
+pushd example/ios >/dev/null
+pod repo update || exit 1
+pod update || exit 1
+popd >/dev/null
+
+# Reload dependencies
+flutter pub get || exit 1

--- a/.github/scripts/update_native_sdks.sh
+++ b/.github/scripts/update_native_sdks.sh
@@ -26,8 +26,6 @@ echo "Android SDK last version is $androidVersion"
 
 pushd android >/dev/null
 sed -i~ -e "s|io.didomi.sdk:android:[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}|io.didomi.sdk:android:$androidVersion|g" build.gradle || exit 1
-# Cleanup backup files
-find . -type f -name '*~' -delete
 popd >/dev/null
 
 # Update ios SDK Version
@@ -41,9 +39,10 @@ echo "iOS SDK last version is $iOSVersion"
 
 pushd ios >/dev/null
 sed -i~ -e "s|s.dependency       'Didomi-XCFramework', '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.dependency       'Didomi-XCFramework', '$iOSVersion'|g" didomi_sdk.podspec || exit 1
+popd >/dev/null
+
 # Cleanup backup files
 find . -type f -name '*~' -delete
-popd >/dev/null
 
 pushd example/ios >/dev/null
 pod repo update || exit 1


### PR DESCRIPTION
Closes: CMP-2856

Split native sdks version update and flutter version increment:
`update_native_sdks.sh` is updating the native SDKs only
`update_bridge_version.sh` is incrementing the bridge version and adding a new entry to the change log
`update.sh` is updating the native SDKs before incrementing the bridge version and adding a new entry to the change log