### PR TITLE
revert publication plugin to 1.3.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Publish
-        uses: sakebook/actions-flutter-pub-publisher@v1.4.1
+        # Version 1.4.1 will fail because of `Potential leak of Google OAuth Refresh Token detected.`
+        uses: sakebook/actions-flutter-pub-publisher@v1.3.1
         with:
           credential: ${{ secrets.PUB_DEV_CREDENTIALS }}
           flutter_package: true


### PR DESCRIPTION
Move back to 1.3.1
see: https://github.com/sakebook/actions-flutter-pub-publisher/issues/27