### PR TITLE
CMP-4102 mac mini M2 path issues

### DIFF
--- a/.github/scripts/uitests_for_android.sh
+++ b/.github/scripts/uitests_for_android.sh
@@ -6,7 +6,10 @@
 
 # Set up environment variables for Mac Mini M2
 export ANDROID_SDK_ROOT=/Users/administrator/Library/Android/sdk
+export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
+export PATH=$PATH:$ANDROID_SDK_ROOT/tools
+export PATH=$PATH:$ANDROID_SDK_ROOT/tools/bin
 
 # Search for device name
 DEVICE=$(emulator -list-avds | head -n 1)

--- a/.github/scripts/uitests_for_android.sh
+++ b/.github/scripts/uitests_for_android.sh
@@ -4,6 +4,10 @@
 # Launch UI tests for Android
 #----------------------------------------------------------
 
+# Set up environment variables for Mac Mini M2
+export ANDROID_SDK_ROOT=/Users/administrator/Library/Android/sdk
+export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
+
 # Search for device name
 DEVICE=$(emulator -list-avds | head -n 1)
 
@@ -22,8 +26,10 @@ cd ./example || exit 1
 # Cleanup workspace
 flutter clean || exit 1
 
-# Delete logs (for local usage)
-rm machine.log
+# Delete logs if exists (for local usage)
+if [ -f machine.log ]; then
+  rm machine.log
+fi
 
 # Run tests and print logs
 flutter test --machine -d emulator-5554 -r expanded integration_test >machine.log || exit 1


### PR DESCRIPTION
- Add environment vars for Mac Mini M2 runner.
- Check if file `machine.log` exists before trying to remove it.