### PR TITLE
CMP-4509 - SPI parameter for `showPreferences` function

### DIFF
--- a/example/lib/widgets/show_hide_preferences.dart
+++ b/example/lib/widgets/show_hide_preferences.dart
@@ -31,10 +31,6 @@ class _ShowHidePreferencesState extends BaseSampleWidgetState<ShowHidePreference
     if (requestedView != null) {
       if (_hideAfterAWhile) {
         Future.delayed(const Duration(seconds: HIDE_DELAY_SECONDS), () {
-          // TODO('Remove this once hide preference is fixed on native sdks')
-          if (requestedView == PreferencesView.vendors) {
-            DidomiSdk.hidePreferences();
-          }
           return DidomiSdk.hidePreferences();
         });
       }
@@ -83,6 +79,17 @@ class _ShowHidePreferencesState extends BaseSampleWidgetState<ShowHidePreference
               key: Key("PreferencesForPurposes"),
               title: const Text("Purposes"),
               value: PreferencesView.purposes,
+              groupValue: _requestedView,
+              onChanged: (PreferencesView? value) {
+                setState(() {
+                  _requestedView = value;
+                });
+              },
+            ),
+            RadioListTile<PreferencesView>(
+              key: Key("PreferencesForSensitivePersonalInformation"),
+              title: const Text("Sensitive Personal Information"),
+              value: PreferencesView.sensitivePersonalInformation,
               groupValue: _requestedView,
               onChanged: (PreferencesView? value) {
                 setState(() {

--- a/ios/Classes/SwiftDidomiSdkPlugin.swift
+++ b/ios/Classes/SwiftDidomiSdkPlugin.swift
@@ -280,17 +280,25 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
             result(FlutterError.init(code: "sdk_not_ready", message: SwiftDidomiSdkPlugin.didomiNotReadyException, details: nil))
             return
         }
+
         let viewController: UIViewController = (UIApplication.shared.delegate?.window??.rootViewController)!
         guard let args = call.arguments as? Dictionary<String, Any> else {
             result(FlutterError.init(code: "invalid_args", message: "Wrong arguments for initialize", details: nil))
             return
         }
+
         let view: Didomi.Views
-        if let viewArgument = args["view"] as? String, viewArgument == "vendors" {
+        let viewArgument = args["view"] as? String
+
+        switch viewArgument {
+        case "vendors":
             view = .vendors
-        } else {
+        case "sensitive-personal-information":
+            view = .sensitivePersonalInformation
+        default:
             view = .purposes
         }
+
         Didomi.shared.showPreferences(controller: viewController, view: view)
         result(nil)
     }

--- a/lib/didomi_sdk.dart
+++ b/lib/didomi_sdk.dart
@@ -118,7 +118,7 @@ class DidomiSdk {
 
   /// Show the preferences screen
   static Future<void> showPreferences({PreferencesView view = PreferencesView.purposes}) async {
-    await _channel.invokeMethod("showPreferences", {"view": view.toString().split('.').last});
+    await _channel.invokeMethod("showPreferences", {"view": view.name});
   }
 
   /// Hide the preferences screen

--- a/lib/preferences_view.dart
+++ b/lib/preferences_view.dart
@@ -3,6 +3,24 @@ enum PreferencesView {
   /// Main preferences screen
   purposes,
 
+  /// Sensitive Personal Information preferences screen
+  sensitivePersonalInformation,
+
   /// Vendors preferences screen
   vendors
+}
+
+/// Extension to get the name of the enum
+extension PreferencesViewExtension on PreferencesView {
+  String get name {
+    switch (this) {
+      case PreferencesView.sensitivePersonalInformation:
+        return "sensitive-personal-information";
+      case PreferencesView.vendors:
+        return "vendors";
+      default:
+        // purposes is the default value
+        return "purposes";
+    }
+  }
 }


### PR DESCRIPTION
SPI parameter for `showPreferences` function
- Refactor enum to get a `name` property from each case
- Handle new SPI value for iOS
- Add SPI value from sample widget

Note: this change will need native SDKs >= 2.0.0 to be fully functional on Android