### PR TITLE
modify retrieve the rootViewController for usage with SceneDelegate

### DIFF
--- a/ios/Classes/SwiftDidomiSdkPlugin.swift
+++ b/ios/Classes/SwiftDidomiSdkPlugin.swift
@@ -212,10 +212,22 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
     }
     
     func setupUI(result: @escaping FlutterResult) {
-        let viewController: UIViewController =
-            (UIApplication.shared.delegate?.window??.rootViewController)!
-        Didomi.shared.setupUI(containerController: viewController)
+        let viewController: UIViewController? = getViewController()
+        if(viewController == nil) {
+            result(FlutterError.init(code: "sdk_not_ready", message: SwiftDidomiSdkPlugin.didomiNotReadyException, details: nil))
+            return;
+        }
+        Didomi.shared.setupUI(containerController: viewController!)
         result(nil)
+    }
+    
+    private func getViewController() -> UIViewController? {
+        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
+                  let viewController = window.rootViewController else {
+            return nil;
+            }
+        
+        return viewController
     }
 
     func reset(result: @escaping FlutterResult) {
@@ -259,7 +271,11 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let viewController: UIViewController = (UIApplication.shared.delegate?.window??.rootViewController)!
+        let viewController: UIViewController? = getViewController()
+        if(viewController == nil) {
+            result(FlutterError.init(code: "sdk_not_ready", message: SwiftDidomiSdkPlugin.didomiNotReadyException, details: nil))
+            return;
+        }
         guard let args = call.arguments as? Dictionary<String, Any> else {
             result(FlutterError.init(code: "invalid_args", message: "Wrong arguments for initialize", details: nil))
             return
@@ -277,7 +293,7 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
             view = .purposes
         }
 
-        Didomi.shared.showPreferences(controller: viewController, view: view)
+        Didomi.shared.showPreferences(controller: viewController!, view: view)
         result(nil)
     }
 
@@ -667,7 +683,7 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        if let viewController: UIViewController = UIApplication.shared.delegate?.window??.rootViewController {
+        if let viewController: UIViewController = getViewController() {
             Didomi.shared.setUser(id: userId, containerController: viewController)
         } else {
             Didomi.shared.setUser(id: userId)
@@ -754,7 +770,7 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
                 salt: salt)
         }
 
-        if let viewController: UIViewController = UIApplication.shared.delegate?.window??.rootViewController {
+        if let viewController: UIViewController = getViewController() {
             Didomi.shared.setUser(userAuthParams: parameters, containerController: viewController)
         } else {
             Didomi.shared.setUser(userAuthParams: parameters)
@@ -834,7 +850,7 @@ public class SwiftDidomiSdkPlugin: NSObject, FlutterPlugin {
                 secretID: secretId,
                 initializationVector: initializationVector)
         }
-        if let viewController: UIViewController = UIApplication.shared.delegate?.window??.rootViewController {
+        if let viewController: UIViewController = getViewController() {
             Didomi.shared.setUser(userAuthParams: parameters, containerController: viewController)
         } else {
             Didomi.shared.setUser(userAuthParams: parameters)


### PR DESCRIPTION
We need to use SceneDelegate because of CarPlay, but we're encountering a crash with Didomi.

The issue occurs in lines 215 and 262 of the file SwiftDidomiSdkPlugin.swift. You can view the relevant code sections here:
- [Line 215](https://github.com/didomi/flutter/blob/fafff3cefb1686efc07c57db04b1475feb4edbde/ios/Classes/SwiftDidomiSdkPlugin.swift#L215C9-L215C45)
- [Line 262](https://github.com/didomi/flutter/blob/fafff3cefb1686efc07c57db04b1475feb4edbde/ios/Classes/SwiftDidomiSdkPlugin.swift#L262)

The root cause seems to be that rootViewController is nil, likely because we are using SceneDelegate.

To resolve this, I modified the code and added a function to SwiftDidomiSdkPlugin.swift to correctly retrieve the rootViewController. This solution works perfectly in our app.