### PR TITLE
CMP-4651: ignored deprecated_member_use_from_same_package linting rule

### DIFF
--- a/lib/events/events_handler.dart
+++ b/lib/events/events_handler.dart
@@ -294,6 +294,7 @@ class EventsHandler {
       case "onSyncDone":
         final String organizationUserId = event["organizationUserId"].toString();
         for (var listener in listeners) {
+          // ignore: deprecated_member_use_from_same_package
           listener.onSyncDone(organizationUserId);
         }
         break;


### PR DESCRIPTION
Ignored `deprecated_member_use_from_same_package` linting rule since we can't remove the `SyncDone` event yet.