### PR TITLE
Support OUID in SyncReady event

### DIFF
--- a/android/src/main/kotlin/io/didomi/fluttersdk/DidomiEventStreamHandler.kt
+++ b/android/src/main/kotlin/io/didomi/fluttersdk/DidomiEventStreamHandler.kt
@@ -5,6 +5,8 @@ import io.didomi.sdk.functionalinterfaces.DidomiEventListener
 import io.flutter.plugin.common.EventChannel
 import org.json.JSONObject
 import io.didomi.sdk.models.CurrentUserStatus.VendorStatus
+import android.os.Handler
+import android.os.Looper
 
 /**
  * Handler for SDK events
@@ -204,7 +206,7 @@ class DidomiEventStreamHandler : EventChannel.StreamHandler, DidomiEventListener
     override fun syncReady(event: SyncReadyEvent) {
         syncReadyEventIndex++
         syncReadyEventReferences.put(syncReadyEventIndex, event)
-        sendEvent("onSyncReady", mapOf("statusApplied" to event.statusApplied, "syncReadyEventIndex" to syncReadyEventIndex))
+        sendEvent("onSyncReady", mapOf("organizationUserId" to event.organizationUserId, "statusApplied" to event.statusApplied, "syncReadyEventIndex" to syncReadyEventIndex))
     }
 
     override fun syncDone(event: SyncDoneEvent) {
@@ -255,7 +257,9 @@ class DidomiEventStreamHandler : EventChannel.StreamHandler, DidomiEventListener
     private fun sendEvent(eventType: String, arguments: Map<String, *>? = null) {
         val event = mutableMapOf<String, Any?>("type" to eventType)
         arguments?.also { event.putAll(it) }
-        this.eventSink?.success(event)
+        Handler(Looper.getMainLooper()).post {
+            this.eventSink?.success(event)
+        }
     }
 
     // Request to execute a specific syncAcknowledged callback. It returns **true** if the API Event was sent, **false** otherwise.

--- a/example/integration_test/set_user_test.dart
+++ b/example/integration_test/set_user_test.dart
@@ -34,7 +34,7 @@ void main() {
   final reset = find.byKey(Key("reset"));
   final listKey = Key("components_list");
 
-  String? syncUserId;
+  String? syncDoneUserId;
   bool isReady = false;
   bool syncError = false;
   bool consentChanged = false;
@@ -45,7 +45,7 @@ void main() {
     isReady = true;
   };
   listener.onConsentChanged = () {
-    syncUserId = null;
+    syncDoneUserId = null;
     syncError = false;
     consentChanged = true;
     syncReadyEvent = null;
@@ -55,7 +55,7 @@ void main() {
   };
   // ignore: deprecated_member_use
   listener.onSyncDone = (String userId) {
-    syncUserId = userId != "null" ? userId : null;
+    syncDoneUserId = userId != "null" ? userId : null;
   };
   listener.onSyncError = (String error) {
     syncError = true;
@@ -67,18 +67,19 @@ void main() {
   Future waitForSync(WidgetTester tester) async {
     // Wait for sync result
     await tester.runAsync(() async {
-      while (syncUserId == null && !syncError) {
+      while (syncReadyEvent == null && !syncError) {
         await Future.delayed(Duration(milliseconds: 100));
       }
     });
   }
 
   // Assert sync event is triggered correctly.
-  Future<void> assertSyncEvent(WidgetTester tester) async {
+  Future<void> assertSyncReadyEvent(WidgetTester tester) async {
     // First time the sync event is triggered. Status is applied and API Event triggered only once.
     assert(syncReadyEvent?.statusApplied == true);
     assert((await syncReadyEvent?.syncAcknowledged()) == true);
     assert((await syncReadyEvent?.syncAcknowledged()) == false);
+    assert(syncReadyEvent?.statusApplied == false);
 
     // We reinitialize the SDK to re-trigger the sync event.
     await tester.tap(initializeBtnFinder);
@@ -89,11 +90,12 @@ void main() {
     assert(syncReadyEvent?.statusApplied == false);
     assert((await syncReadyEvent?.syncAcknowledged()) == false);
     assert((await syncReadyEvent?.syncAcknowledged()) == false);
+    assert(syncReadyEvent?.organizationUserId == userId);
   }
 
   // Reset all variables used for assertion.
   void resetExpectedSyncValues() {
-    syncUserId = null;
+    syncDoneUserId = null;
     syncError = false;
     consentChanged = false;
     syncReadyEvent = null;
@@ -101,14 +103,15 @@ void main() {
 
   // Assert that all the expected sync variables are populated.
   void assertExpectedSyncValuesArePopulated() {
-    assert(syncUserId == userId);
+    assert(syncDoneUserId == userId);
     assert(syncError == false);
     assert(syncReadyEvent != null);
+    assert(syncReadyEvent?.organizationUserId == userId);
   }
 
   // Assert that all the expected sync variables are empty.
   void assertExpectedSyncValuesAreEmpty() {
-    assert(syncUserId == null);
+    assert(syncDoneUserId == null);
     assert(syncError == false);
     assert(syncReadyEvent == null);
   }
@@ -126,7 +129,7 @@ void main() {
       app.main();
       await tester.pumpAndSettle();
 
-      assert(syncUserId == null);
+      assert(syncDoneUserId == null);
       assert(syncError == false);
       assert(syncReadyEvent == null);
 
@@ -179,7 +182,7 @@ void main() {
       await waitForSync(tester);
 
       // Encryption parameters are not valid
-      assert(syncUserId == null);
+      assert(syncDoneUserId == null);
       assert(syncError == true);
       assert(syncReadyEvent == null);
     });
@@ -209,10 +212,10 @@ void main() {
 
       await waitForSync(tester);
 
-      assert(syncUserId == userId);
+      assert(syncDoneUserId == userId);
       assert(syncError == false);
 
-      await assertSyncEvent(tester);
+      await assertSyncReadyEvent(tester);
     });
 
     testWidgets("Click setUser with id and underage false", (WidgetTester tester) async {
@@ -254,10 +257,10 @@ void main() {
 
       await waitForSync(tester);
 
-      assert(syncUserId == userId);
+      assert(syncDoneUserId == userId);
       assert(syncError == false);
 
-      await assertSyncEvent(tester);
+      await assertSyncReadyEvent(tester);
     });
 
     testWidgets("Click setUser with id and underage true", (WidgetTester tester) async {
@@ -299,10 +302,10 @@ void main() {
 
       await waitForSync(tester);
 
-      assert(syncUserId == userId);
+      assert(syncDoneUserId == userId);
       assert(syncError == false);
 
-      await assertSyncEvent(tester);
+      await assertSyncReadyEvent(tester);
     });
 
     testWidgets("Click setUser with encryption", (WidgetTester tester) async {

--- a/example/integration_test/set_user_test.dart
+++ b/example/integration_test/set_user_test.dart
@@ -79,7 +79,7 @@ void main() {
     assert(syncReadyEvent?.statusApplied == true);
     assert((await syncReadyEvent?.syncAcknowledged()) == true);
     assert((await syncReadyEvent?.syncAcknowledged()) == false);
-    assert(syncReadyEvent?.statusApplied == false);
+    assert(syncReadyEvent?.organizationUserId == userId);
 
     // We reinitialize the SDK to re-trigger the sync event.
     await tester.tap(initializeBtnFinder);

--- a/example/integration_test/util/initialize_helper.dart
+++ b/example/integration_test/util/initialize_helper.dart
@@ -17,5 +17,6 @@ class InitializeHelper {
       }
       await expectLater(await DidomiSdk.isReady, isTrue);
     });
+    await Future.delayed(Duration(milliseconds: 100));
   }
 }

--- a/ios/Classes/DidomiEventStreamHandler.swift
+++ b/ios/Classes/DidomiEventStreamHandler.swift
@@ -146,7 +146,7 @@ class DidomiEventStreamHandler : NSObject, FlutterStreamHandler {
             }
             strongSelf.syncReadyEventIndex += 1
             strongSelf.syncReadyEventReferences[strongSelf.syncReadyEventIndex] = event
-            strongSelf.sendEvent(eventType: "onSyncReady", arguments: ["statusApplied": event.statusApplied, "syncReadyEventIndex": strongSelf.syncReadyEventIndex])
+            strongSelf.sendEvent(eventType: "onSyncReady", arguments: ["organizationUserId": event.organizationUserId, "statusApplied": event.statusApplied, "syncReadyEventIndex": strongSelf.syncReadyEventIndex])
         }
         eventListener.onSyncDone = { [weak self] event, organizationUserId in
             self?.sendEvent(eventType: "onSyncDone", arguments: ["organizationUserId": organizationUserId])

--- a/lib/events/events_handler.dart
+++ b/lib/events/events_handler.dart
@@ -280,6 +280,7 @@ class EventsHandler {
       case "onSyncReady":
         for (var listener in listeners) {
           final SyncReadyEvent newEvent = SyncReadyEvent(
+            event["organizationUserId"],
             event["statusApplied"],
             () async {
               // This method allows us to execute the syncAcknowledged callback from the flutter side.

--- a/lib/events/sync_ready_event.dart
+++ b/lib/events/sync_ready_event.dart
@@ -1,8 +1,10 @@
 class SyncReadyEvent {
+  // The organization user ID corresponding to the event
+  String organizationUserId;
   // Boolean that indicates whether remote user status has been applied locally.
   bool statusApplied;
   // Function used to send a Sync Acknowledged API Event. Returns **true** if the API Event was sent, **false** otherwise.
   Future<bool> Function() syncAcknowledged = () async => false;
 
-  SyncReadyEvent(this.statusApplied, this.syncAcknowledged);
+  SyncReadyEvent(this.organizationUserId, this.statusApplied, this.syncAcknowledged);
 }


### PR DESCRIPTION
Add `organizationUserId` parameter in `SyncReady` event.