### PR TITLE
Fix Lint warning (initialization to null)

### DIFF
--- a/lib/didomi_sdk.dart
+++ b/lib/didomi_sdk.dart
@@ -337,16 +337,16 @@ class DidomiSdk {
   static Future<void> clearUser() async => await _channel.invokeMethod("clearUser");
 
   /// Set user information
-  static Future<void> setUser(String organizationUserId, [bool? isUnderage = null]) async =>
+  static Future<void> setUser(String organizationUserId, [bool? isUnderage]) async =>
       await _channel.invokeMethod("setUser", {"organizationUserId": organizationUserId, "isUnderage": isUnderage});
 
   /// Set user information and check for missing consent
-  static Future<void> setUserAndSetupUI(String organizationUserId, [bool? isUnderage = null]) async =>
+  static Future<void> setUserAndSetupUI(String organizationUserId, [bool? isUnderage]) async =>
       await _channel.invokeMethod("setUserAndSetupUI", {"organizationUserId": organizationUserId, "isUnderage": isUnderage});
 
   /// Set user information with authentication
   static Future<void> setUserWithAuthParams(UserAuthParams userAuthParams,
-      [List<UserAuthParams>? synchronizedUsers, bool? isUnderage = null]) async {
+      [List<UserAuthParams>? synchronizedUsers, bool? isUnderage]) async {
     Map<String, dynamic> jsonUserAuthParams = userAuthParams.toJson();
     List<Map<String, dynamic>>? jsonSynchronizedUsers = synchronizedUsers?.map((user) => user.toJson()).toList();
     return await _channel.invokeMethod("setUserWithAuthParams", {
@@ -358,7 +358,7 @@ class DidomiSdk {
 
   /// Set user information with authentication and check for missing consent
   static Future<void> setUserWithAuthParamsAndSetupUI(UserAuthParams userAuthParams,
-      [List<UserAuthParams>? synchronizedUsers, bool? isUnderage = null]) async {
+      [List<UserAuthParams>? synchronizedUsers, bool? isUnderage]) async {
     Map<String, dynamic> jsonUserAuthParams = userAuthParams.toJson();
     List<Map<String, dynamic>>? jsonSynchronizedUsers = synchronizedUsers?.map((user) => user.toJson()).toList();
     return await _channel.invokeMethod("setUserWithAuthParamsAndSetupUI", {


### PR DESCRIPTION
Fix Lint warning

     info - lib/didomi_sdk.dart:340:59 - Redundant initialization to 'null'. Try removing the initializer. - avoid_init_to_null
     info - lib/didomi_sdk.dart:344:69 - Redundant initialization to 'null'. Try removing the initializer. - avoid_init_to_null
     info - lib/didomi_sdk.dart:349:49 - Redundant initialization to 'null'. Try removing the initializer. - avoid_init_to_null
     info - lib/didomi_sdk.dart:361:49 - Redundant initialization to 'null'. Try removing the initializer. - avoid_init_to_null