### PR TITLE
Deprecate references to SPI purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Release Note
 
+## 2.9.0
+- Update latest versions of native Android (2.18.0) and iOS (2.18.0) sdks
+- Deprecate methods and parameters related to SPI purposes
+
 ## 2.8.0
 - Update latest versions of native Android (2.17.0) and iOS (2.17.0) sdks
+- Handle `organizationUserId` field in SyncReadyEvent 
+- Android: Add `jvmTarget` in `build.gradle` `kotlinOptions`
 
 ## 2.7.0
 - Update latest versions of native Android (2.10.1) and iOS (2.11.1) sdks
+- Add support for vendor count methods
 
 ## 2.6.0
 - Update latest versions of native Android (2.10.0) and iOS (2.11.0) sdks

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 //noinspection GrPackage
 
 group = "io.didomi.fluttersdk"
-version = "2.8.0"
+version = "2.9.0"
 
 buildscript {
     ext.kotlin_version = "1.9.20"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Didomi-XCFramework (2.18.0)
-  - didomi_sdk (2.8.0):
+  - didomi_sdk (2.9.0):
     - Didomi-XCFramework (= 2.18.0)
     - Flutter
   - Flutter (1.0.0)
@@ -26,7 +26,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Didomi-XCFramework: cf8c43b0c954b19c423f8a2f7ec23124f6eb5231
-  didomi_sdk: fdf241ddc1e70bfecd5ef0c8bfe245bef6485c02
+  didomi_sdk: 0e5fad1253cc98982b7019edc01aa8c8b81fa425
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
 

--- a/ios/didomi_sdk.podspec
+++ b/ios/didomi_sdk.podspec
@@ -4,12 +4,12 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'didomi_sdk'
-  s.version          = '2.8.0'
+  s.version          = '2.9.0'
   s.summary          = 'Didomi CMP Plugin.'
   s.homepage         = 'https://github.com/didomi/flutter'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Didomi ' => 'tech@didomi.io' }
-  s.source           = { :path => 'git@github.com:didomi/flutter.git', :tag => '2.8.0' }
+  s.source           = { :path => 'git@github.com:didomi/flutter.git', :tag => '2.9.0' }
   s.source_files     = 'Classes/**/*'
   s.dependency       'Flutter'
   s.dependency       'Didomi-XCFramework', '2.18.0'

--- a/lib/events/event_listener.dart
+++ b/lib/events/event_listener.dart
@@ -38,6 +38,7 @@ class EventListener {
   dynamic Function() onNoticeClickViewVendors = () {};
 
   /// SPI screen was opened from the notice
+  @Deprecated("SPI purposes are now displayed in preferences screen, use onNoticeClickMoreInfo instead.")
   dynamic Function() onNoticeClickViewSPIPurposes = () {};
 
   /// Preferences screen was opened from the notice
@@ -72,6 +73,7 @@ class EventListener {
   dynamic Function() onPreferencesClickViewVendors = () {};
 
   /// SPI screen was opened from preferences screen
+  @Deprecated("SPI purposes are now displayed in preferences screen.")
   dynamic Function() onPreferencesClickViewSPIPurposes = () {};
 
   /// Save button was clicked from preferences screen
@@ -113,18 +115,23 @@ class EventListener {
    */
 
   /// User switched a SPI purpose status to Agree
+  @Deprecated("SPI purposes are now treated as other purposes, use onPreferencesClickPurposeAgree instead.")
   dynamic Function(String purposeId) onPreferencesClickSPIPurposeAgree = (purposeId) {};
 
   /// User switched a SPI purpose status to Disagree
+  @Deprecated("SPI purposes are now treated as other purposes, use onPreferencesClickPurposeDisagree instead.")
   dynamic Function(String purposeId) onPreferencesClickSPIPurposeDisagree = (purposeId) {};
 
   /// User switched a SPI category status to Agree
+  @Deprecated("SPI purposes are now treated as other purposes, use onPreferencesClickCategoryAgree instead.")
   dynamic Function(String categoryId) onPreferencesClickSPICategoryAgree = (categoryId) {};
 
   /// User switched a SPI category status to Disagree
+  @Deprecated("SPI purposes are now treated as other purposes, use onPreferencesClickCategoryDisagree instead.")
   dynamic Function(String categoryId) onPreferencesClickSPICategoryDisagree = (categoryId) {};
 
   /// Save button was clicked from SPI screen
+  @Deprecated("SPI purposes are now displayed in preferences screen, use onPreferencesClickSaveChoices instead.")
   dynamic Function() onPreferencesClickSPIPurposeSaveChoices = () {};
 
   /*

--- a/lib/events/events_handler.dart
+++ b/lib/events/events_handler.dart
@@ -105,12 +105,6 @@ class EventsHandler {
         }
         break;
 
-      case "onNoticeClickViewSPIPurposes":
-        for (var listener in listeners) {
-          listener.onNoticeClickViewSPIPurposes();
-        }
-        break;
-
       case "onNoticeClickMoreInfo":
         for (var listener in listeners) {
           listener.onNoticeClickMoreInfo();
@@ -166,12 +160,6 @@ class EventsHandler {
       case "onPreferencesClickViewVendors":
         for (var listener in listeners) {
           listener.onPreferencesClickViewVendors();
-        }
-        break;
-
-      case "onPreferencesClickViewSPIPurposes":
-        for (var listener in listeners) {
-          listener.onPreferencesClickViewSPIPurposes();
         }
         break;
 
@@ -234,40 +222,6 @@ class EventsHandler {
       case "onPreferencesClickDisagreeToAllVendors":
         for (var listener in listeners) {
           listener.onPreferencesClickDisagreeToAllVendors();
-        }
-        break;
-
-      case "onPreferencesClickSPIPurposeAgree":
-        final String purposeId = event["purposeId"].toString();
-        for (var listener in listeners) {
-          listener.onPreferencesClickSPIPurposeAgree(purposeId);
-        }
-        break;
-
-      case "onPreferencesClickSPIPurposeDisagree":
-        final String purposeId = event["purposeId"].toString();
-        for (var listener in listeners) {
-          listener.onPreferencesClickSPIPurposeDisagree(purposeId);
-        }
-        break;
-
-      case "onPreferencesClickSPICategoryAgree":
-        final String categoryId = event["categoryId"].toString();
-        for (var listener in listeners) {
-          listener.onPreferencesClickSPICategoryAgree(categoryId);
-        }
-        break;
-
-      case "onPreferencesClickSPICategoryDisagree":
-        final String categoryId = event["categoryId"].toString();
-        for (var listener in listeners) {
-          listener.onPreferencesClickSPICategoryDisagree(categoryId);
-        }
-        break;
-
-      case "onPreferencesClickSPIPurposeSaveChoices":
-        for (var listener in listeners) {
-          listener.onPreferencesClickSPIPurposeSaveChoices();
         }
         break;
 

--- a/lib/preferences_view.dart
+++ b/lib/preferences_view.dart
@@ -4,6 +4,7 @@ enum PreferencesView {
   purposes,
 
   /// Sensitive Personal Information preferences screen
+  @Deprecated("SPI purposes are now displayed in Preferences screen, use PreferencesView.purposes instead.")
   sensitivePersonalInformation,
 
   /// Vendors preferences screen
@@ -13,14 +14,9 @@ enum PreferencesView {
 /// Extension to get the name of the enum
 extension PreferencesViewExtension on PreferencesView {
   String get name {
-    switch (this) {
-      case PreferencesView.sensitivePersonalInformation:
-        return "sensitive-personal-information";
-      case PreferencesView.vendors:
-        return "vendors";
-      default:
-        // purposes is the default value
-        return "purposes";
+    if (this == PreferencesView.vendors) {
+      return "vendors";
     }
+    return "purposes";
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: didomi_sdk
 description: The Didomi CMP Plugin allows companies to collect, store, and leverage user consent under GDPR, CCPA, and other data privacy regulations.
-version: 2.8.0
+version: 2.9.0
 repository: https://github.com/didomi/flutter
 
 environment:


### PR DESCRIPTION
Since SPI are no longer displayed in a separate screen, we can deprecate corresponding fields and stop expecting related events.