### PR TITLE
Fix publication issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,3 +114,21 @@ jobs:
           name: ios-app
           path: example/build/ios/iphoneos/*.ipa
           retention-days: 5
+
+  publish:
+    name: Publish Flutter SDK (DRY RUN)
+    needs: [ build_ios, build_android ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish
+        # Version 1.4.1 will fail because of `Potential leak of Google OAuth Refresh Token detected.`
+        uses: sakebook/actions-flutter-pub-publisher@v1.3.1
+        with:
+          credential: ${{ secrets.PUB_DEV_CREDENTIALS }}
+          flutter_package: true
+          skip_test: true
+          dry_run: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,4 @@
+analyzer:
+  errors:
+    deprecated_member_use: ignore
+    deprecated_member_use_from_same_package: ignore

--- a/lib/parameters/didomi_initialize_parameters.dart
+++ b/lib/parameters/didomi_initialize_parameters.dart
@@ -49,16 +49,16 @@ class DidomiInitializeParameters {
 
   DidomiInitializeParameters(
       {required this.apiKey,
-      this.localConfigurationPath = null,
-      this.remoteConfigurationUrl = null,
-      this.providerId = null,
+      this.localConfigurationPath,
+      this.remoteConfigurationUrl,
+      this.providerId,
       this.disableDidomiRemoteConfig = false,
-      this.languageCode = null,
-      this.noticeId = null,
-      this.androidTvNoticeId = null,
+      this.languageCode,
+      this.noticeId,
+      this.androidTvNoticeId,
       this.androidTvEnabled = false,
-      this.countryCode = null,
-      this.regionCode = null,
+      this.countryCode,
+      this.regionCode,
       this.isUnderage = false});
 
   Map<String, dynamic> toJson() => {

--- a/lib/parameters/didomi_initialize_parameters.dart
+++ b/lib/parameters/didomi_initialize_parameters.dart
@@ -31,7 +31,7 @@ class DidomiInitializeParameters {
 
   /// If set to true, when launched on a AndroidTV device, the SDK will display TV notice:
   /// * Only Didomi remote config is allowed
-  /// * Connected TV must be enabled for your organization, and [apiKey] / [tvNoticeId] must correspond to a TV notice in the console.
+  /// * Connected TV must be enabled for your organization, and [apiKey] / [androidTvNoticeId] must correspond to a TV notice in the console.
   /// If false or not set, the SDK will not be able to initialize on a TV device.
   bool androidTvEnabled = false;
 

--- a/lib/parameters/didomi_user_parameters.dart
+++ b/lib/parameters/didomi_user_parameters.dart
@@ -11,7 +11,7 @@ class DidomiUserParameters {
   /// Whether the user is underage (null will keep the setting from initialization or from a previous call to `setUser`)
   bool? isUnderage;
 
-  DidomiUserParameters({required this.userAuth, this.dcsUserAuth = null, this.isUnderage = null});
+  DidomiUserParameters({required this.userAuth, this.dcsUserAuth, this.isUnderage});
 
   Map<String, dynamic> toJson() => {
         'userAuth': userAuth.toJson(),
@@ -27,9 +27,9 @@ class DidomiMultiUserParameters extends DidomiUserParameters {
 
   DidomiMultiUserParameters(
       {required UserAuth userAuth,
-      UserAuthParams? dcsUserAuth = null,
-      this.synchronizedUsers = null,
-      bool? isUnderage = null})
+      UserAuthParams? dcsUserAuth,
+      this.synchronizedUsers,
+      bool? isUnderage})
       : super(userAuth: userAuth, dcsUserAuth: dcsUserAuth, isUnderage: isUnderage);
 
   @override


### PR DESCRIPTION
Publication failed because of 2 different issues:
- null init from `DidomiInitializeParameters` `DidomiUserParameters` and `DidomiMultiUserParameters` constructors.
- Deprecated message for `disableDidomiRemoteConfig` parameter.

This PR is fixing those issues by removing null init and adding analyze rules to ignore deprecation message.

I'm also adding a new step to the build workflow to launch a publication dry run once both android and iOS build are successful.  