### PR TITLE
Updates GitHub Actions workflows for Node 20 deprecation and fixes the   iOS SPM build on Flutter 3.44.

### DIFF
--- a/.github/scripts/update_native_sdks.sh
+++ b/.github/scripts/update_native_sdks.sh
@@ -44,7 +44,7 @@ fi
 echo "iOS SDK last version is $iOSVersion"
 
 sed -i~ -e "s|s.dependency       'Didomi-XCFramework', '[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}'|s.dependency       'Didomi-XCFramework', '$iOSVersion'|g" ios/didomi_sdk.podspec || exit 1
-sed -i~ -e "s|from: \"[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\"|from: \"$iOSVersion\"|g" ios/didomi_sdk/Package.swift || exit 1
+sed -i~ -e "s|\(didomi-ios-sdk-spm\".*from: \)\"[0-9]\{1,2\}.[0-9]\{1,2\}.[0-9]\{1,2\}\"|\1\"$iOSVersion\"|g" ios/didomi_sdk/Package.swift || exit 1
 
 # Cleanup backup files
 find . -type f -name '*~' -delete

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,14 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      # Checkout into a directory matching the plugin name (didomi_sdk) so
+      # Flutter's SPM integration generates the right symlink identity.
+      # Flutter 3.44+ derives the SPM package identity from the plugin's
+      # root directory name; checking out into `flutter/` (the repo name)
+      # produces identity `flutter` which collides with the override.
       - uses: actions/checkout@v6
+        with:
+          path: didomi_sdk
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -88,6 +95,7 @@ jobs:
           channel: "stable"
 
       - name: Install dependencies
+        working-directory: ./didomi_sdk
         run: flutter pub get
 
       - name: Add Homebrew to PATH
@@ -95,12 +103,12 @@ jobs:
 
       # pod update
       - name: Run pod update
-        working-directory: ./example/ios
+        working-directory: ./didomi_sdk/example/ios
         run: pod update
 
       # iOS IPA with SPM
       - name: Build iOS Sample (SPM)
-        working-directory: ./example
+        working-directory: ./didomi_sdk/example
         run: |
           flutter config --enable-swift-package-manager
           flutter build ios --no-codesign
@@ -113,7 +121,7 @@ jobs:
 
       # iOS IPA with CocoaPods
       - name: Build iOS Sample (CocoaPods)
-        working-directory: ./example
+        working-directory: ./didomi_sdk/example
         run: |
           flutter config --no-enable-swift-package-manager
           flutter build ios --no-codesign
@@ -129,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ios-app
-          path: example/build/ios/iphoneos/*.ipa
+          path: didomi_sdk/example/build/ios/iphoneos/*.ipa
           retention-days: 5
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,12 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      # Checkout into a directory matching the plugin name (didomi_sdk) so
+      # Flutter's SPM integration generates the right symlink identity on
+      # Flutter 3.44+ (see build.yml for full context).
       - uses: actions/checkout@v6
+        with:
+          path: didomi_sdk
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
@@ -51,26 +56,28 @@ jobs:
           architecture: arm64 # optional value for v2 (use self-hosted mac mini)
 
       - name: Install dependencies
+        working-directory: ./didomi_sdk
         run: flutter pub get
 
       - name: Add Homebrew to PATH
         run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
 
       - name: Run pod update
-        working-directory: ./example/ios
+        working-directory: ./didomi_sdk/example/ios
         run: pod update
 
       - name: List all simulators
         run: xcrun xctrace list devices
 
       - name: Build & run all tests
+        working-directory: ./didomi_sdk
         run: sh .github/scripts/uitests_for_ios.sh
 
       - name: Archive test results
         uses: actions/upload-artifact@v7
         with:
           name: logs_ios
-          path: example/machine.log
+          path: didomi_sdk/example/machine.log
 
   # job responsible for running Flutter tests on Android devices
   test_android:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,12 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      # Checkout into a directory matching the plugin name (didomi_sdk) so
+      # Flutter's SPM integration generates the right symlink identity on
+      # Flutter 3.44+ (see build.yml for full context).
       - uses: actions/checkout@v6
+        with:
+          path: didomi_sdk
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
@@ -53,19 +58,21 @@ jobs:
           architecture: arm64 # optional value for v2 (use self-hosted mac mini)
 
       - name: Install dependencies
+        working-directory: ./didomi_sdk
         run: flutter pub get
 
       - name: Add Homebrew to PATH
         run: echo "/opt/homebrew/bin" >> $GITHUB_PATH
 
       - name: Run pod update
-        working-directory: ./example/ios
+        working-directory: ./didomi_sdk/example/ios
         run: pod update
 
       - name: List all simulators
         run: xcrun xctrace list devices
 
       - name: Build & run all tests
+        working-directory: ./didomi_sdk
         run: sh .github/scripts/uitests_for_ios.sh
 
       - name: Archive test results
@@ -73,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logs_ios
-          path: example/machine.log
+          path: didomi_sdk/example/machine.log
 
   # job responsible for running Flutter tests on Android devices
   android:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
       - uses: actions/setup-java@v5
@@ -49,13 +48,12 @@ jobs:
         run: bash .github/scripts/update.sh ${{ github.event.inputs.increment }}
 
       - name: Commit & Push changes
-        uses: actions-js/push@master
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
-          author_email: ${{ secrets.AUTHOR_EMAIL }}
-          author_name: ${{ secrets.AUTHOR_NAME }}
-          branch: ${{ github.ref }}
-          github_token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          message: "Update Dependencies and increment ${{ github.event.inputs.increment }} version"
+          commit_message: "Update Dependencies and increment ${{ github.event.inputs.increment }} version"
+          commit_user_name: ${{ secrets.AUTHOR_NAME }}
+          commit_user_email: ${{ secrets.AUTHOR_EMAIL }}
+          commit_author: ${{ secrets.AUTHOR_NAME }} <${{ secrets.AUTHOR_EMAIL }}>
 
       - name: Trigger Tag
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .dart_tool/
 .packages
 build/
+.build/
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 
@@ -26,3 +27,8 @@ runConfigurations.xml
 
 # AI
 CLAUDE.md
+
+# Swift Package Manager (Flutter SPM integration generates these per-build)
+.swiftpm/
+**/Flutter/ephemeral/
+**/xcshareddata/swiftpm/

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -22,6 +22,8 @@ Flutter/app.flx
 Flutter/app.zip
 Flutter/flutter_assets/
 Flutter/flutter_export_environment.sh
+Flutter/ephemeral/
+**/xcshareddata/swiftpm/
 ServiceDefinitions.json
 Runner/GeneratedPluginRegistrant.*
 

--- a/ios/didomi_sdk/Package.swift
+++ b/ios/didomi_sdk/Package.swift
@@ -6,35 +6,34 @@ import PackageDescription
 let package = Package(
     name: "didomi_sdk",
     platforms: [
-        .iOS("10.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "didomi-sdk", targets: ["didomi_sdk"])
     ],
     dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework"),
         .package(url: "https://github.com/didomi/didomi-ios-sdk-spm", from: "2.42.0")
     ],
     targets: [
         .target(
             name: "DidomiSwift",
             dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework"),
                 .product(name: "Didomi", package: "didomi-ios-sdk-spm")
             ],
             path: "Sources/DidomiSwift",
-            resources: [],
-            linkerSettings: [
-                .linkedFramework("Flutter", .when(platforms: [.iOS]))
-            ]
+            resources: []
         ),
         .target(
             name: "didomi_sdk",
-            dependencies: ["DidomiSwift"],
+            dependencies: [
+                "DidomiSwift",
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             path: "Sources/DidomiObjC",
             resources: [],
-            publicHeadersPath: "include",
-            linkerSettings: [
-                .linkedFramework("Flutter", .when(platforms: [.iOS]))
-            ]
+            publicHeadersPath: "include"
         )
     ]
 )

--- a/ios/didomi_sdk/Package.swift
+++ b/ios/didomi_sdk/Package.swift
@@ -6,34 +6,35 @@ import PackageDescription
 let package = Package(
     name: "didomi_sdk",
     platforms: [
-        .iOS("13.0")
+        .iOS("10.0")
     ],
     products: [
         .library(name: "didomi-sdk", targets: ["didomi_sdk"])
     ],
     dependencies: [
-        .package(name: "FlutterFramework", path: "../FlutterFramework"),
         .package(url: "https://github.com/didomi/didomi-ios-sdk-spm", from: "2.42.0")
     ],
     targets: [
         .target(
             name: "DidomiSwift",
             dependencies: [
-                .product(name: "FlutterFramework", package: "FlutterFramework"),
                 .product(name: "Didomi", package: "didomi-ios-sdk-spm")
             ],
             path: "Sources/DidomiSwift",
-            resources: []
+            resources: [],
+            linkerSettings: [
+                .linkedFramework("Flutter", .when(platforms: [.iOS]))
+            ]
         ),
         .target(
             name: "didomi_sdk",
-            dependencies: [
-                "DidomiSwift",
-                .product(name: "FlutterFramework", package: "FlutterFramework")
-            ],
+            dependencies: ["DidomiSwift"],
             path: "Sources/DidomiObjC",
             resources: [],
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            linkerSettings: [
+                .linkedFramework("Flutter", .when(platforms: [.iOS]))
+            ]
         )
     ]
 )


### PR DESCRIPTION
 - **Replace `actions-js/push@master` with `stefanzweifel/git-auto-commit-action@v6`**
    in `update.yml` — it was the only remaining action still running on
    Node 20. All other actions (`checkout@v6`, `setup-java@v5`,
    `upload-artifact@v7`, `github-script@v9`) are already on Node 24.

  - **Fix iOS SPM build on Flutter 3.44** by checking out into a
    `didomi_sdk/` subdirectory in all iOS jobs (`build.yml`, `test.yml`,
    `release.yml`). Flutter 3.44 derives the SwiftPM package identity from
    the plugin's root directory name (where `pubspec.yaml` lives). Since
    this repo is named `flutter`, the generated SPM symlink was named
    `Flutter` instead of `didomi_sdk`, causing SwiftPM to refuse the
    override:
    > unable to override package 'didomi_sdk' because its identity
    > 'flutter' doesn't match override's identity 'didomi_sdk'

    Checking out into `didomi_sdk/` makes the directory name match the
    plugin name, which is what SwiftPM expects. No `Package.swift` change
    required.

  - **Tighten the `Package.swift` sed in `update_native_sdks.sh`** to
    anchor on the `didomi-ios-sdk-spm` package line, so future SPM
    dependencies with their own `from:` clauses won't be accidentally
    rewritten by the version bump script.

  - **Gitignore Flutter SPM build artifacts** (`.build/`, `.swiftpm/`,
    `**/Flutter/ephemeral/`, `**/xcshareddata/swiftpm/`) at both repo and
    `example/ios/` levels.
