### PR TITLE
feat: add sdkPath and apiPath to DidomiInitializeParameters

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,7 +64,7 @@ android {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
-    implementation("io.didomi.sdk:android:2.44.0")
+    implementation("io.didomi.sdk:android:2.45.0")
     implementation("androidx.multidex:multidex:2.0.1")
     implementation("com.google.code.gson:gson:2.13.2")
 }

--- a/android/src/main/kotlin/io/didomi/fluttersdk/DidomiPlugin.kt
+++ b/android/src/main/kotlin/io/didomi/fluttersdk/DidomiPlugin.kt
@@ -254,6 +254,8 @@ class DidomiPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 countryCode = jsonDidomiInitializeParameters["countryCode"] as? String,
                 regionCode = jsonDidomiInitializeParameters["regionCode"] as? String,
                 isUnderage = jsonDidomiInitializeParameters["isUnderage"] as Boolean,
+                sdkPath = jsonDidomiInitializeParameters["sdkPath"] as? String,
+                apiPath = jsonDidomiInitializeParameters["apiPath"] as? String,
             )
 
             Didomi.getInstance().initialize(it.application, didomiInitializeParameters)

--- a/ios/didomi_sdk.podspec
+++ b/ios/didomi_sdk.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files     = 'didomi_sdk/Sources/**/*.{swift,h,m}'
   s.public_header_files = 'didomi_sdk/Sources/DidomiObjC/include/**/*.h'
   s.dependency       'Flutter'
-  s.dependency       'Didomi-XCFramework', '2.44.0'
+  s.dependency       'Didomi-XCFramework', '2.45.0'
   s.platform         = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/didomi_sdk/Sources/DidomiSwift/SwiftDidomiSdkPlugin.swift
+++ b/ios/didomi_sdk/Sources/DidomiSwift/SwiftDidomiSdkPlugin.swift
@@ -200,7 +200,9 @@ import Didomi
             noticeID: jsonDidomiInitializeParameters["noticeId"] as? String,
             countryCode: jsonDidomiInitializeParameters["countryCode"] as? String,
             regionCode: jsonDidomiInitializeParameters["regionCode"] as? String,
-            isUnderage: jsonDidomiInitializeParameters["isUnderage"] as! Bool
+            isUnderage: jsonDidomiInitializeParameters["isUnderage"] as! Bool,
+            sdkPath: jsonDidomiInitializeParameters["sdkPath"] as? String,
+            apiPath: jsonDidomiInitializeParameters["apiPath"] as? String
         )
         Didomi.shared.initialize(parameters)
         result(nil)

--- a/lib/parameters/didomi_initialize_parameters.dart
+++ b/lib/parameters/didomi_initialize_parameters.dart
@@ -47,6 +47,14 @@ class DidomiInitializeParameters {
   /// If set to true, the SDK will only display the underage notice (false by default).
   bool isUnderage = false;
 
+  /// Base URL used to load all static files (didomi_config.json, GVL, IAB vendor list).
+  /// Defaults to the Didomi SDK CDN if not set. Must use HTTPS.
+  String? sdkPath;
+
+  /// Base URL used for all API requests (Consents API, cross-device sync, API Events).
+  /// Defaults to the Didomi API if not set. Must use HTTPS.
+  String? apiPath;
+
   DidomiInitializeParameters(
       {required this.apiKey,
       this.localConfigurationPath,
@@ -59,7 +67,9 @@ class DidomiInitializeParameters {
       this.androidTvEnabled = false,
       this.countryCode,
       this.regionCode,
-      this.isUnderage = false});
+      this.isUnderage = false,
+      this.sdkPath,
+      this.apiPath});
 
   Map<String, dynamic> toJson() => {
         'apiKey': apiKey,
@@ -74,5 +84,7 @@ class DidomiInitializeParameters {
         'countryCode': countryCode,
         'regionCode': regionCode,
         'isUnderage': isUnderage,
+        'sdkPath': sdkPath,
+        'apiPath': apiPath,
       };
 }


### PR DESCRIPTION
Adds two optional parameters to DidomiInitializeParameters to allow overriding the default Didomi CDN and API base URLs:

- `sdkPath`: overrides the base URL for static files (config, GVL, IAB vendor list)
- `apiPath`: overrides the base URL for API requests (consent sync, API events)

Both values must use HTTPS. Requires iOS SDK 2.45.0 / Android SDK 2.45.0.