### PR TITLE
Notify release slack channel after publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,3 +28,29 @@ jobs:
           flutter_package: true
           skip_test: true
           dry_run: false
+
+  notify:
+    name: Notify Slack
+    needs: publish
+    # Release context is only available when triggered by a release (not workflow_dispatch)
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send release announcement to Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.RELEASES_SLACK_WEBHOOK }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          # Extract the changelog from the release body:
+          # drop the "More info" trailer and the leading "- " list markers.
+          # Trailing blank lines are stripped by the command substitution.
+          changelog=$(printf '%s\n' "$RELEASE_BODY" | tr -d '\r' | sed -e '/^More info:/,$d' -e 's/^- //')
+
+          text=$(printf '*Flutter SDK version `%s`* is now available :rocket:\n```%s```\nhttps://pub.dev/packages/didomi_sdk/versions/%s\n%s' \
+            "$RELEASE_TAG" "$changelog" "$RELEASE_TAG" "$RELEASE_URL")
+
+          jq -n --arg text "$text" '{ text: $text }' \
+            | curl --silent --show-error --fail -X POST -H 'Content-Type: application/json' -d @- "$SLACK_WEBHOOK"


### PR DESCRIPTION
Notify release slack channel after publication.

Use new repository secret `RELEASES_SLACK_WEBHOOK` to post a message to the `releases` slack channel once the publication is successful. the message is customized with the version number, the release change log and the flutter dev link.