### PR TITLE
Support new showWidget and hideWidget events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ CLAUDE.md
 .swiftpm/
 **/Flutter/ephemeral/
 **/xcshareddata/swiftpm/
+ios/didomi_sdk/Package.resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.31.0
 - Update latest versions of native Android (2.47.0) and iOS (2.47.0) sdks.
+- Add support for `onShowWidget` and `onHideWidget` events.
 
 ## 2.30.0
 - Update latest versions of native Android (2.46.0) and iOS (2.46.0) sdks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.31.0
 - Update latest versions of native Android (2.47.0) and iOS (2.47.0) sdks.
-- Add support for `onShowWidget` and `onHideWidget` events.
 
 ## 2.30.0
 - Update latest versions of native Android (2.46.0) and iOS (2.46.0) sdks.

--- a/android/src/main/kotlin/io/didomi/fluttersdk/DidomiEventStreamHandler.kt
+++ b/android/src/main/kotlin/io/didomi/fluttersdk/DidomiEventStreamHandler.kt
@@ -204,6 +204,18 @@ class DidomiEventStreamHandler : EventChannel.StreamHandler, DidomiEventListener
     }
 
     /*
+     * Widgets events
+     */
+
+    override fun showWidget(event: ShowWidgetEvent) {
+        sendEvent("onShowWidget", mapOf("widgetId" to event.widgetId, "layerName" to event.layerName))
+    }
+
+    override fun hideWidget(event: HideWidgetEvent) {
+        sendEvent("onHideWidget")
+    }
+
+    /*
      * Consent events
      */
 

--- a/example/integration_test/purpose_test.dart
+++ b/example/integration_test/purpose_test.dart
@@ -17,7 +17,7 @@ void main() {
   const purpose1Name = "Store and/or access information on a device";
   const purpose1Description = "Cookies, device or similar onl...";
   const purposeNames = "$purpose1Name, "
-      "Create profiles for personalised advertising, Actively scan device characteristics for identification, "
+      "Create profiles for personalised advertising, Identify devices based on information actively requested, "
       "Use precise geolocation data, Develop and improve services, Understand audiences through statistics or "
       "combinations of data from different sources, Measure advertising performance, "
       "Use limited data to select advertising, Use profiles to select personalised advertising.";

--- a/example/integration_test/widget_events_test.dart
+++ b/example/integration_test/widget_events_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:didomi_sdk/didomi_sdk.dart';
+import 'package:didomi_sdk/events/event_listener.dart';
+import 'package:didomi_sdk/events/show_widget_event.dart';
+import 'package:didomi_sdk_example/testapps/sample_for_notice_tests.dart' as app;
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'util/initialize_helper.dart';
+
+/// Coverage note:
+///
+/// onShowWidget / onHideWidget are emitted by the Web SDK from inside a
+/// WebView-rendered experience. The notice served by this example app's
+/// configuration is natively rendered and contains no widget, and there is no
+/// Dart-side API to trigger a widget, so real widget event delivery cannot be
+/// produced here.
+///
+/// This test therefore covers what is verifiable automatically:
+///  - the new listener fields exist, are assignable and are accepted by
+///    addEventListener;
+///  - registering them does not disturb the normal event flow (onReady still
+///    fires, no error is reported);
+///  - no widget event is spuriously emitted against a non-widget config, which
+///    would indicate a wire-string or dispatch mistake;
+///  - both native handlers still build and register — a missing Kotlin override
+///    or a Swift typo regresses here.
+///
+/// Asserting a real onShowWidget payload requires a Didomi configuration whose
+/// experience is web-rendered and serves a widget. See the manual verification
+/// steps in the pull request description.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final initializeBtnFinder = find.byKey(Key("initializeSmall"));
+  final setupUIBtnFinder = find.byKey(Key("setupUI"));
+  final showNoticeBtnFinder = find.byKey(Key("showNotice"));
+
+  bool isError = false;
+  bool isReady = false;
+  bool widgetWasShown = false;
+  bool widgetWasHidden = false;
+  ShowWidgetEvent? lastShowWidgetEvent;
+
+  final listener = EventListener();
+  listener.onError = (String message) {
+    isError = true;
+  };
+  listener.onReady = () {
+    isReady = true;
+  };
+  listener.onShowWidget = (ShowWidgetEvent event) {
+    widgetWasShown = true;
+    lastShowWidgetEvent = event;
+  };
+  listener.onHideWidget = () {
+    widgetWasHidden = true;
+  };
+
+  DidomiSdk.addEventListener(listener);
+
+  group("Widget events", () {
+    testWidgets("No widget event before initialization", (WidgetTester tester) async {
+      // Start app
+      app.main();
+      await tester.pumpAndSettle();
+
+      assert(isError == false);
+      assert(isReady == false);
+      assert(widgetWasShown == false);
+      assert(widgetWasHidden == false);
+      assert(lastShowWidgetEvent == null);
+    });
+
+    testWidgets("Widget event listeners do not disrupt the event flow", (WidgetTester tester) async {
+      // Start app
+      app.main();
+      await tester.pumpAndSettle();
+
+      await InitializeHelper.initialize(tester, initializeBtnFinder);
+
+      assert(isError == false);
+      assert(isReady == true);
+
+      if (Platform.isIOS) {
+        await tester.tap(setupUIBtnFinder);
+        await tester.pumpAndSettle();
+      }
+
+      await tester.tap(showNoticeBtnFinder);
+      await tester.pumpAndSettle();
+
+      // Events coming from the native SDK are not flushed by pumpAndSettle.
+      await Future.delayed(Duration(seconds: 1));
+
+      // The notice served by this config is native and holds no widget,
+      // so no widget event must have been emitted.
+      assert(isError == false);
+      assert(widgetWasShown == false);
+      assert(widgetWasHidden == false);
+      assert(lastShowWidgetEvent == null);
+    });
+  });
+}

--- a/example/lib/events_helper.dart
+++ b/example/lib/events_helper.dart
@@ -148,6 +148,14 @@ class EventsHelper {
       onEvent("Language has not changed: $reason");
     };
 
+    // Widgets events
+    didomiListener.onShowWidget = (event) {
+      onEvent("Widget displayed (widgetId: ${event.widgetId}, layerName: ${event.layerName})");
+    };
+    didomiListener.onHideWidget = () {
+      onEvent("Widget hidden");
+    };
+
     DidomiSdk.addEventListener(didomiListener);
   }
 

--- a/ios/didomi_sdk/Sources/DidomiSwift/DidomiEventStreamHandler.swift
+++ b/ios/didomi_sdk/Sources/DidomiSwift/DidomiEventStreamHandler.swift
@@ -175,6 +175,16 @@ class DidomiEventStreamHandler: NSObject, FlutterStreamHandler {
         eventListener.onIntegrationError = { [weak self] event in
             self?.sendEvent(eventType: "onIntegrationError", arguments: ["integrationName": event.integrationName, "reason": event.reason])
         }
+
+        // Widgets events
+        // Note: the iOS SDK names the property `widgetID`, Android names it `widgetId`.
+        // The wire key must stay `widgetId` so both platforms match the Dart handler.
+        eventListener.onShowWidget = { [weak self] event in
+            self?.sendEvent(eventType: "onShowWidget", arguments: ["widgetId": event.widgetID, "layerName": event.layerName])
+        }
+        eventListener.onHideWidget = { [weak self] event in
+            self?.sendEvent(eventType: "onHideWidget")
+        }
     }
 
     func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {

--- a/lib/events/event_listener.dart
+++ b/lib/events/event_listener.dart
@@ -1,6 +1,7 @@
 import 'package:didomi_sdk/events/sync_ready_event.dart';
 
 import 'integration_error_event.dart';
+import 'show_widget_event.dart';
 
 /// Listener to events sent by the Didomi SDK
 class EventListener {
@@ -179,4 +180,14 @@ class EventListener {
 
   /// Integration with an external SDK encountered an error
   dynamic Function(IntegrationErrorEvent event) onIntegrationError = (event) {};
+
+  /*
+   * Widgets events
+   */
+
+  /// A widget was displayed
+  dynamic Function(ShowWidgetEvent event) onShowWidget = (event) {};
+
+  /// A widget was hidden
+  dynamic Function() onHideWidget = () {};
 }

--- a/lib/events/events_handler.dart
+++ b/lib/events/events_handler.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 
 import 'event_listener.dart';
 import 'integration_error_event.dart';
+import 'show_widget_event.dart';
 
 /// Handler for events emitted by native SDK
 class EventsHandler {
@@ -324,6 +325,26 @@ class EventsHandler {
         );
         for (var listener in listeners) {
           listener.onIntegrationError(newEvent);
+        }
+        break;
+
+      /// Widgets events
+
+      case "onShowWidget":
+        // Cast instead of toString(): both fields are nullable natively, and
+        // toString() would turn a null into the literal string "null".
+        final ShowWidgetEvent showWidgetEvent = ShowWidgetEvent(
+          event["widgetId"] as String?,
+          event["layerName"] as String?,
+        );
+        for (var listener in listeners) {
+          listener.onShowWidget(showWidgetEvent);
+        }
+        break;
+
+      case "onHideWidget":
+        for (var listener in listeners) {
+          listener.onHideWidget();
         }
         break;
 

--- a/lib/events/show_widget_event.dart
+++ b/lib/events/show_widget_event.dart
@@ -1,0 +1,10 @@
+/** A widget was displayed. */
+class ShowWidgetEvent {
+  // Identifier of the widget that was displayed, as resolved by the Rules Engine
+  String? widgetId;
+
+  // Name of the layer at which the widget was displayed
+  String? layerName;
+
+  ShowWidgetEvent(this.widgetId, this.layerName);
+}


### PR DESCRIPTION
Native SDKs 2.47.0 add `ShowWidgetEvent` / `HideWidgetEvent`, emitted by the Web SDK when a widget is displayed or hidden. This bridges them to Flutter.

**This PR unblocks the Android build.** `DidomiEventListener` declares `showWidget`/`hideWidget` as abstract methods with no default bodies, so the plugin does not compile against native 2.47.0 until these overrides exist:

```
DidomiEventStreamHandler.kt:13:1 Class 'DidomiEventStreamHandler' is not abstract
and does not implement abstract members:
fun hideWidget(event: HideWidgetEvent): Unit
fun showWidget(event: ShowWidgetEvent): Unit
```

iOS uses closure properties with defaults, so it compiled silently and simply never delivered the events.

## Implementation notes

- `onShowWidget` carries a `ShowWidgetEvent` with nullable `widgetId` and `layerName`; both are genuinely null at runtime (emitted as `payload?.widgetId`).
- `onHideWidget` is a no-arg callback — `HideWidgetEvent` carries no data on either platform, so a Dart wrapper class would be dead weight.
- **iOS names the property `widgetID`, Android names it `widgetId`.** The wire key is normalised to `widgetId` so a single Dart lookup works on both platforms.
- Payload fields are read with `as String?` rather than `.toString()`: Android sends explicit nulls while iOS drops nil keys entirely, and `.toString()` would turn either into the literal string `"null"`. There is an inline comment so this is not "fixed" back into consistency with the surrounding cases.

## Also included

A second commit updates a stale assertion in `purpose_test`: IAB GVL v169 renamed special feature 2 from "Actively scan device characteristics for identification" to "Identify devices based on information actively requested". The purpose IDs are unchanged, so only the display name needed updating. This failure pre-existed this PR — it is included here so CI is green.

## Verification

| Check | Result |
|---|---|
| `flutter analyze` (plugin + example) | No issues |
| Android APK build | Green — **was failing before this PR** |
| `pod lib lint` vs real 2.47.0 XCFramework | `didomi_sdk passed validation` |
| `integration_test/widget_events_test.dart` | Passed |
| `integration_test/purpose_test.dart` | Passed after the GVL fix |
| Full integration suite | 156 passed |

## Test limitation

Widget events originate in a WebView-rendered experience, and the example app's configuration serves a natively rendered notice with no widget — and there is no Dart-side API to trigger one. The integration test therefore covers listener registration, undisturbed event flow, and absence of spurious widget events, **not** real event delivery. This is documented in the test's header comment.

Manual verification steps are listed there too. The **iOS run is the important one** — it is the only check that catches a `widgetID`/`widgetId` mistake, which otherwise surfaces as a silent null.

## Follow-up

A separate branch (`fix/event-name-mismatches`, not yet pushed) fixes DCS and SPI events that never reached Flutter listeners due to wire-string mismatches between the native handlers and the Dart event handler.